### PR TITLE
Allow configuration of internal 'carbon' metric prefix used

### DIFF
--- a/conf/carbon.conf.example
+++ b/conf/carbon.conf.example
@@ -156,6 +156,15 @@ WHISPER_AUTOFLUSH = False
 # from [carbon] section.
 # You can then specify the --instance=b option to manage this instance
 
+# By default, carbon itself will log statistics (such as
+# a count, metricsReceived) under the metric path top named
+# 'carbon'. If you have a need to, uncomment the following
+# setting to put these statistics under '_carbon' instead
+# (or set it to whatever you'd like). This is useful, for
+# instance, when you have metrics coming in from a *host*
+# named carbon.
+# CARBON_DATA_PREFIX = _carbon
+
 
 [relay]
 LINE_RECEIVER_INTERFACE = 0.0.0.0
@@ -206,6 +215,15 @@ USE_FLOW_CONTROL = True
 # CONF_DIR/whitelist and CONF_DIR/blacklist. If the whitelist is missing or
 # empty, all metrics will pass through
 # USE_WHITELIST = False
+
+# By default, carbon itself will log statistics (such as
+# a count, metricsReceived) under the metric path top named
+# 'carbon'. If you have a need to, uncomment the following
+# setting to put these statistics under '_carbon' instead
+# (or set it to whatever you'd like). This is useful, for
+# instance, when you have metrics coming in from a *host*
+# named carbon.
+# CARBON_DATA_PREFIX = _carbon
 
 
 [aggregator]
@@ -259,3 +277,12 @@ MAX_AGGREGATION_INTERVALS = 5
 # CONF_DIR/whitelist and CONF_DIR/blacklist. If the whitelist is missing or
 # empty, all metrics will pass through
 # USE_WHITELIST = False
+
+# By default, carbon itself will log statistics (such as
+# a count, metricsReceived) under the metric path top named
+# 'carbon'. If you have a need to, uncomment the following
+# setting to put these statistics under '_carbon' instead
+# (or set it to whatever you'd like). This is useful, for
+# instance, when you have metrics coming in from a *host*
+# named carbon.
+# CARBON_DATA_PREFIX = _carbon

--- a/lib/carbon/instrumentation.py
+++ b/lib/carbon/instrumentation.py
@@ -15,6 +15,9 @@ rusage = getrusage(RUSAGE_SELF)
 lastUsage = rusage.ru_utime + rusage.ru_stime
 lastUsageTime = time.time()
 
+# NOTE: Referencing settings in this *top level scope* will
+# give you *defaults* only. Probably not what you wanted.
+
 # TODO(chrismd) refactor the graphite metrics hierarchy to be cleaner,
 # more consistent, and make room for frontend metrics.
 #metric_prefix = "Graphite.backend.%(program)s.%(instance)s." % settings
@@ -114,26 +117,29 @@ def recordMetrics():
 
 
 def cache_record(metric, value):
+    prefix = settings.CARBON_DATA_PREFIX
     if settings.instance is None:
-      fullMetric = 'carbon.agents.%s.%s' % (HOSTNAME, metric)
+      fullMetric = '%s.agents.%s.%s' % (prefix, HOSTNAME, metric)
     else:
-      fullMetric = 'carbon.agents.%s-%s.%s' % (HOSTNAME, settings.instance, metric)
+      fullMetric = '%s.agents.%s-%s.%s' % (prefix, HOSTNAME, settings.instance, metric)
     datapoint = (time.time(), value)
     cache.MetricCache.store(fullMetric, datapoint)
 
 def relay_record(metric, value):
+    prefix = settings.CARBON_DATA_PREFIX
     if settings.instance is None:
-      fullMetric = 'carbon.relays.%s.%s' % (HOSTNAME, metric)
+      fullMetric = '%s.relays.%s.%s' % (prefix, HOSTNAME, metric)
     else:
-      fullMetric = 'carbon.relays.%s-%s.%s' % (HOSTNAME, settings.instance, metric)
+      fullMetric = '%s.relays.%s-%s.%s' % (prefix, HOSTNAME, settings.instance, metric)
     datapoint = (time.time(), value)
     events.metricGenerated(fullMetric, datapoint)
 
 def aggregator_record(metric, value):
+    prefix = settings.CARBON_DATA_PREFIX
     if settings.instance is None:
-      fullMetric = 'carbon.aggregator.%s.%s' % (HOSTNAME, metric)
+      fullMetric = '%s.aggregator.%s.%s' % (prefix, HOSTNAME, metric)
     else:
-      fullMetric = 'carbon.aggregator.%s-%s.%s' % (HOSTNAME, settings.instance, metric)
+      fullMetric = '%s.aggregator.%s-%s.%s' % (prefix, HOSTNAME, settings.instance, metric)
     datapoint = (time.time(), value)
     events.metricGenerated(fullMetric, datapoint)
 


### PR DESCRIPTION
carbon logs its own information with a prefix of 'carbon'
by default. This code allows setting CARBON_DATA_PREFIX
in carbon.conf where relevant to override the default
of 'carbon'. This is useful in environments where a hostname
(reporting metrics) may be named 'carbon', causing a dilemma.
