### PR TITLE
Expedite the Carbon cache daemon shutdown

### DIFF
--- a/conf/carbon.conf.example
+++ b/conf/carbon.conf.example
@@ -47,6 +47,12 @@ MAX_CACHE_SIZE = inf
 # take effect and increase the overall throughput accordingly.
 MAX_UPDATES_PER_SECOND = 500
 
+# If defined, this changes the MAX_UPDATES_PER_SECOND in Carbon when a
+# stop/shutdown is initiated.  This helps when MAX_UPDATES_PER_SECOND is
+# relatively low and carbon has cached a lot of updates; it enables the carbon
+# daemon to shutdown more quickly. 
+# MAX_UPDATES_PER_SECOND_ON_SHUTDOWN = 1000
+
 # Softly limits the number of whisper files that get created each minute.
 # Setting this value low (like at 50) is a good way to ensure your graphite
 # system will not be adversely impacted when a bunch of new metrics are

--- a/lib/carbon/writer.py
+++ b/lib/carbon/writer.py
@@ -179,6 +179,13 @@ def reloadAggregationSchemas():
     log.err()
 
 
+def shutdownModifyUpdateSpeed():
+    try:
+    	settings.MAX_UPDATES_PER_SECOND = settings.MAX_UPDATES_PER_SECOND_ON_SHUTDOWN
+        log.msg("Carbon shutting down.  Changed the update rate to: " + str(settings.MAX_UPDATES_PER_SECOND_ON_SHUTDOWN))
+    except KeyError:
+        log.msg("Carbon shutting down.  Update rate not changed")
+
 class WriterService(Service):
 
     def __init__(self):
@@ -188,6 +195,7 @@ class WriterService(Service):
     def startService(self):
         self.storage_reload_task.start(60, False)
         self.aggregation_reload_task.start(60, False)
+        reactor.addSystemEventTrigger('before', 'shutdown', shutdownModifyUpdateSpeed)
         reactor.callInThread(writeForever)
         Service.startService(self)
 


### PR DESCRIPTION
The purpose of this change is to expedite the shutdown of the Carbon cache daemon by raising the maximum number of updates per second during the shutdown phase of the daemon.  The default behavior is unchanged, but the behavior changes when an additional configuration item is added to the carbon.conf file.  The option is included in carbon.conf.example, commented out.
