### PR TITLE
Fixing startup error: InvalidConfiguration is defined in whisper module.

### DIFF
--- a/lib/carbon/storage.py
+++ b/lib/carbon/storage.py
@@ -136,8 +136,8 @@ def loadStorageSchemas():
     try:
       whisper.validateArchiveList(archiveList)
       schemaList.append(mySchema)
-    except InvalidConfiguration, e:
-      log.msg("Invalid schemas found in %s: %s" % (section, e.message) )
+    except whisper.InvalidConfiguration, e:
+      log.msg("Invalid schemas found in %s: %s" % (section, e) )
   
   schemaList.append(defaultSchema)
   return schemaList


### PR DESCRIPTION
Carbon wouldn't otherwise even run.
