### PR TITLE
Percentile Aggregation Method

### DIFF
--- a/lib/carbon/aggregator/rules.py
+++ b/lib/carbon/aggregator/rules.py
@@ -67,13 +67,12 @@ class RuleManager:
       raise
 
 
-def percentile(N, percent, key=lambda x:x):
+def percentile(N, percent):
     """
     Find the percentile of a list of values.
 
     @parameter N - is a list of values. N will be sorted.
     @parameter percent - a float value from 0.0 to 1.0.
-    @parameter key - optional key function to compute value from each element of N.
 
     @return - the percentile of the values
     """
@@ -84,9 +83,11 @@ def percentile(N, percent, key=lambda x:x):
     f = math.floor(k)
     c = math.ceil(k)
     if f == c:
-        return key(N[int(k)])
-    d0 = key(N[int(f)]) * (c-k)
-    d1 = key(N[int(c)]) * (k-f)
+      return N[int(k)]
+    # this interpolation seems kindof crazy to me, but hey
+    # I'm not a math major
+    d0 = N[int(f)] * (c-k)
+    d1 = N[int(c)] * (k-f)
     return d0+d1
 
 
@@ -121,7 +122,7 @@ class AggregationRule:
         except:
           log.err("Failed to interpolate template %s with fields %s" % (self.output_template, extracted_fields))
 
-        self.cache[metric_path] = (match.groupdict(), result)
+        self.cache[metric_path] = result
 
     return self.cache.get(metric_path)
 

--- a/lib/carbon/aggregator/rules.py
+++ b/lib/carbon/aggregator/rules.py
@@ -1,10 +1,13 @@
+import math
 import time
 import re
+from functools import partial
 from os.path import exists, getmtime
 from twisted.internet.task import LoopingCall
 from carbon import log
 from carbon.aggregator.buffers import BufferManager
 
+# <metric>.p10 (60) = p10 <<metric>>.histogram.<bucket>
 
 class RuleManager:
   def __init__(self):
@@ -64,6 +67,29 @@ class RuleManager:
       raise
 
 
+def percentile(N, percent, key=lambda x:x):
+    """
+    Find the percentile of a list of values.
+
+    @parameter N - is a list of values. N will be sorted.
+    @parameter percent - a float value from 0.0 to 1.0.
+    @parameter key - optional key function to compute value from each element of N.
+
+    @return - the percentile of the values
+    """
+    if not N:
+        return None
+    N = sorted(N)
+    k = (len(N)-1) * percent
+    f = math.floor(k)
+    c = math.ceil(k)
+    if f == c:
+        return key(N[int(k)])
+    d0 = key(N[int(f)]) * (c-k)
+    d1 = key(N[int(c)]) * (k-f)
+    return d0+d1
+
+
 class AggregationRule:
   def __init__(self, input_pattern, output_pattern, method, frequency):
     self.input_pattern = input_pattern
@@ -72,29 +98,32 @@ class AggregationRule:
     self.frequency = int(frequency)
 
     if method not in AGGREGATION_METHODS:
-      raise ValueError("Invalid aggregation method '%s'" % method)
-
-    self.aggregation_func = AGGREGATION_METHODS[method]
+      if method.startswith("p") and method[1:].isdigit():
+        self.aggregation_func = partial(percentile,
+          percent = (int(method[1:])*1.0)/100)
+      else:
+        raise ValueError("Invalid aggregation method '%s'" % method)
+    else:
+      self.aggregation_func = AGGREGATION_METHODS[method]
     self.build_regex()
     self.build_template()
     self.cache = {}
 
   def get_aggregate_metric(self, metric_path):
-    if metric_path in self.cache:
-      return self.cache[metric_path]
+    if metric_path not in self.cache:
+      match = self.regex.match(metric_path)
+      result = None
 
-    match = self.regex.match(metric_path)
-    result = None
+      if match:
+        extracted_fields = match.groupdict()
+        try:
+          result = self.output_template % extracted_fields
+        except:
+          log.err("Failed to interpolate template %s with fields %s" % (self.output_template, extracted_fields))
 
-    if match:
-      extracted_fields = match.groupdict()
-      try:
-        result = self.output_template % extracted_fields
-      except:
-        log.err("Failed to interpolate template %s with fields %s" % (self.output_template, extracted_fields))
+        self.cache[metric_path] = (match.groupdict(), result)
 
-    self.cache[metric_path] = result
-    return result
+    return self.cache.get(metric_path)
 
   def build_regex(self):
     input_pattern_parts = self.input_pattern.split('.')
@@ -138,7 +167,7 @@ def avg(values):
 
 AGGREGATION_METHODS = {
   'sum' : sum,
-  'avg' : avg,
+  'avg' : avg
 }
 
 # Importable singleton


### PR DESCRIPTION
sorry, the last pull request was half-broken.

----

wondering what the graphite team thinks of this.

initially we had an implementation that could un-parse metrics like
```
box.metric.histogram.10 -- 100
box.metric.histogram.90 -- 12
```

and understand that it meant that it should insert 100 datapoints of value 10, and 12 datapoints of value 90, but that was so gross, I went back to this and will see if our aggregator can handle the volume of dealing with raw values.

--

the rough test of this:

```
aggregation-rules.conf
<metric>.<bucket>.p10 (60) = p10 <<metric>>.histogram.<bucket>                                                                                                                                                                
<metric>.<bucket>.p90 (60) = p90 <<metric>>.histogram.<bucket>
```
```
[blackmad@wfmu twofishes (autocomplete)]$ telnet localhost 2023
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
local.random.histogram.test 10 1344467883
local.random.histogram.test 10 1344467883
local.random.histogram.test 10 1344467883
local.random.histogram.test 10 1344467883
local.random.histogram.test 10 1344467883
local.random.histogram.test 10 1344467883
local.random.histogram.test 10 1344467883
local.random.histogram.test 10 1344467883
local.random.histogram.test 10 1344467883
local.random.histogram.test 5 1344467883

[blackmad@wfmu storage]$ whisper-dump.py ./whisper/local/random/test/p10.wsp | head -n 30
4: 1344459300,        9.5
5: 0,          0
6: 1344459420,        9.5

[blackmad@wfmu storage]$ whisper-dump.py ./whisper/local/random/test/p90.wsp | head -n 30
4: 1344459300,         10
5: 0,          0
6: 1344459420,         10
```