### PR TITLE
Reduce expensive and not very usefull log

### DIFF
--- a/lib/carbon/writer.py
+++ b/lib/carbon/writer.py
@@ -46,7 +46,8 @@ def optimalWriteOrder():
 
   t = time.time()
   metrics.sort(key=lambda item: item[1], reverse=True)  # by queue size, descending
-  log.msg("Sorted %d cache queues in %.6f seconds" % (len(metrics), time.time() - t))
+  log.debug("Sorted %d cache queues in %.6f seconds" % (len(metrics),
+                                                        time.time() - t))
 
   for metric, queueSize in metrics:
     if state.cacheTooFull and MetricCache.size < CACHE_SIZE_LOW_WATERMARK:


### PR DESCRIPTION
``` bash
# du -sh /var/log/graphite/carbon-a/console.log 
489M    /var/log/graphite/carbon-a/console.log
# wc -l /var/log/graphite/carbon-a/console.log
7824309 /var/log/graphite/carbon-a/console.log
# grep -v 'cache queues' /var/log/graphite/carbon-a/console.log | wc -l
79
```

so 99.99% of the logs are like this:

```
20/08/2012 16:04:50 :: Sorted 1 cache queues in 0.000012 seconds
```

it's not very usefull, fill the disk and use a little I/O too.

this is my dev server, on my prod server the file is 4 Gb.
