### PR TITLE
Stop log spam, clean up some more formatting.

### DIFF
--- a/lib/carbon/log.py
+++ b/lib/carbon/log.py
@@ -41,7 +41,7 @@ class CarbonLogObserver(object):
 
   # Default to stdout
   observer = stdout_observer
-   
+
 
 carbonLogObserver = CarbonLogObserver()
 

--- a/lib/carbon/writer.py
+++ b/lib/carbon/writer.py
@@ -114,7 +114,8 @@ def writeCachedDataPoints():
 
         dbDir = dirname(dbFilePath)
         try:
-            os.makedirs(dbDir, 0755)
+            if not exists(dbDir):
+                os.makedirs(dbDir, 0755)
         except OSError as e:
             log.err("%s" % e)
         log.creates("creating database file %s (archive=%s xff=%s agg=%s)" %


### PR DESCRIPTION
Makedirs call in writer.py conditional on the directory not already existing to prevent log spam when new metrics are created in existing directory trees
Cleaned up whitespace in log.py
