### PR TITLE
Allow setting a custom umask

### DIFF
--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -392,6 +392,9 @@ def get_default_parser(usage="%prog [options] <start|stop|status>"):
         "--pidfile", default=None,
         help="Write pid to the given file")
     parser.add_option(
+        "--umask", default=None,
+        help="Use the given umask when creating files")
+    parser.add_option(
         "--config",
         default=None,
         help="Use the given config file")

--- a/lib/carbon/util.py
+++ b/lib/carbon/util.py
@@ -70,6 +70,8 @@ def run_twistd_plugin(filename):
         twistd_options.append("--profile")
     if options.pidfile:
         twistd_options.extend(["--pidfile", options.pidfile])
+    if options.umask:
+        twistd_options.extend(["--umask", options.umask])
 
     # Now for the plugin-specific options.
     twistd_options.append(program)
@@ -79,7 +81,7 @@ def run_twistd_plugin(filename):
 
     for option_name, option_value in vars(options).items():
         if (option_value is not None and
-            option_name not in ("debug", "profile", "pidfile")):
+            option_name not in ("debug", "profile", "pidfile", "umask")):
             twistd_options.extend(["--%s" % option_name.replace("_", "-"),
                                    option_value])
 


### PR DESCRIPTION
It appears work on this was begun in CarbonCacheOptions.postOptions...
I simply added it to the available options.
