### PR TITLE
Enhanced the "invalid line ... ignoring" listener error

### DIFF
--- a/lib/carbon/protocols.py
+++ b/lib/carbon/protocols.py
@@ -65,7 +65,7 @@ class MetricLineReceiver(MetricReceiver, LineOnlyReceiver):
       metric, value, timestamp = line.strip().split()
       datapoint = ( float(timestamp), float(value) )
     except:
-      log.listener('invalid line received from client %s, ignoring' % self.peerName)
+      log.listener('invalid line (%s) received from client %s, ignoring' % (line, self.peerName))
       return
 
     self.metricReceived(metric, datapoint)
@@ -80,7 +80,7 @@ class MetricDatagramReceiver(MetricReceiver, DatagramProtocol):
 
         self.metricReceived(metric, datapoint)
       except:
-        log.listener('invalid line received from %s, ignoring' % host)
+        log.listener('invalid line (%s) received from %s, ignoring' % (line, host))
 
 
 class MetricPickleReceiver(MetricReceiver, Int32StringReceiver):


### PR DESCRIPTION
Added the offending line to the error output, when otherwise skipping a mangled Metric line.

was:
invalid line received from client 10.113.2.37:42652, ignoring

now:
invalid line (server.lax.laxapp23.p7776.VL1  1349267164) received from client 10.113.2.37:42652, ignoring
