### PR TITLE
Carbon to Whisper method call mismatch on 0.9.x branch

### DIFF
--- a/lib/carbon/writer.py
+++ b/lib/carbon/writer.py
@@ -124,8 +124,7 @@ def writeCachedDataPoints():
             archiveConfig,
             xFilesFactor,
             aggregationMethod,
-            settings.WHISPER_SPARSE_CREATE,
-            settings.WHISPER_FALLOCATE_CREATE)
+            settings.WHISPER_SPARSE_CREATE)
         instrumentation.increment('creates')
       # If we've got a rate limit configured lets makes sure we enforce it with
       # a little busy loop.


### PR DESCRIPTION
While following the installation instructions (http://graphite.wikidot.com/installation), I opted for the approach of cloning the git repos and checking out the 0.9.x branches.

Once everything was up and running, I failed to see any data being imported into the system. Tailing the logs, I saw the following exception being repeatedly thrown:

```
25/10/2012 00:00:01 :: Unhandled Error
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 504, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/usr/lib/python2.7/dist-packages/twisted/python/threadpool.py", line 207, in _worker
    result = context.call(ctx, function, *args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/twisted/python/context.py", line 118, in callWithContext
    return self.currentContext().callWithContext(ctx, func, *args, **kw)
  File "/usr/lib/python2.7/dist-packages/twisted/python/context.py", line 81, in callWithContext
    return func(*args,**kw)
--- <exception caught here> ---
  File "/opt/graphite/lib/carbon/writer.py", line 158, in writeForever
    writeCachedDataPoints()
  File "/opt/graphite/lib/carbon/writer.py", line 128, in writeCachedDataPoints
    settings.WHISPER_FALLOCATE_CREATE)
exceptions.TypeError: create() takes at most 5 arguments (6 given)
```

Turns out that the call to whisper.create() on the 0.9.x is not compatible with the whisper method signature on the same branch.

The fix was pretty straight forward. Once I applied it, I was able to start seeing data coming in.

Let me know if there is something missing.

Regards,

-George
