### PR TITLE
Treat MAX_CREATES_PER_MINUTE as a float.

### DIFF
--- a/lib/carbon/writer.py
+++ b/lib/carbon/writer.py
@@ -41,7 +41,7 @@ CREATE_BUCKET = None
 UPDATE_BUCKET = None
 if settings.MAX_CREATES_PER_MINUTE != float('inf'):
   capacity = settings.MAX_CREATES_PER_MINUTE
-  fill_rate = settings.MAX_CREATES_PER_MINUTE / 60
+  fill_rate = float(settings.MAX_CREATES_PER_MINUTE) / 60
   CREATE_BUCKET = TokenBucket(capacity, fill_rate)
 
 if settings.MAX_UPDATES_PER_SECOND != float('inf'):


### PR DESCRIPTION
The MAX value is an integer, but was being divided by 60, and so
was producing an integer result.  Therefore, if MAX was < 60,
the result is 0 and no new metrics are created after the initial
MAX is hit.  If MAX is >= 60, new metrics will be created, though
not at exactly the rate that would be expected.

The TokenBucket expects floating point values, so force the
division to be floating point.

Fixes issue #55.
