### PR TITLE
[minor] Update docs about USER config option

### DIFF
--- a/conf/carbon.conf.example
+++ b/conf/carbon.conf.example
@@ -33,6 +33,9 @@
 # Specify the user to drop privileges to
 # If this is blank carbon runs as the user that invokes it
 # This user must have write access to the local data directory
+#
+# NOTE: This setting must be set under [relay] *and* [aggregator]
+#       to take effect for those daemons as well
 USER =
 
 # Limit the size of the cache to avoid swapping or becoming CPU bound.


### PR DESCRIPTION
It isn't obvious that `USER` and other settings perhaps need to be set under [cache], [relay], and [aggregator]. Update the docs above `USER` to say so.

Eventually, I'm going to likely implement a [global] section that all daemons will read in and use to consolidate some of the duplication. It will require a bit of surgery on conf.py though.
