### PR TITLE
Closing MetricBuffers after all interval buffers are outside the age threshold.

### DIFF
--- a/lib/carbon/aggregator/buffers.py
+++ b/lib/carbon/aggregator/buffers.py
@@ -69,6 +69,10 @@ class MetricBuffer:
 
       if buffer.interval < age_threshold:
         del self.interval_buffers[buffer.interval]
+        if not self.interval_buffers:
+          self.close()
+          self.configured = False
+          del BufferManager.buffers[self.metric_path]
 
   def close(self):
     if self.compute_task and self.compute_task.running:


### PR DESCRIPTION
Closing MetricBuffers after all interval buffers are outside the age threshold.

MetricsBuffers are timers, these timers fire every interval but never die. Every new metric gets a timer that fires every interval. This causes CPU to increase with each new metric even if that metric is sparse. Ultimately leading to 100% CPU usage even when no metrics are being sent.
