### PR TITLE
Fix misreporting cache size/queues metrics

### DIFF
--- a/lib/carbon/instrumentation.py
+++ b/lib/carbon/instrumentation.py
@@ -78,6 +78,13 @@ def recordMetrics():
     cacheQueries = myStats.get('cacheQueries', 0)
     cacheOverflow = myStats.get('cache.overflow', 0)
 
+    # Calculate cache-data-structure-derived metrics prior to storing anything
+    # in the cache itself -- which would otherwise affect said metrics.
+    cache_size = cache.MetricCache.size
+    cache_queues = len(cache.MetricCache)
+    record('cache.size', cache_size)
+    record('cache.queues', cache_queues)
+
     if updateTimes:
       avgUpdateTime = sum(updateTimes) / len(updateTimes)
       record('avgUpdateTime', avgUpdateTime)
@@ -91,8 +98,6 @@ def recordMetrics():
     record('creates', creates)
     record('errors', errors)
     record('cache.queries', cacheQueries)
-    record('cache.queues', len(cache.MetricCache))
-    record('cache.size', cache.MetricCache.size)
     record('cache.overflow', cacheOverflow)
 
   # aggregator metrics


### PR DESCRIPTION
When running Carbon 0.9.x, I noticed my carbon-cache always reporting at least 8.0 for its internal cache size metric. It correctly reports higher numbers when caching actually occurs, but never goes below 8 when inactive.

I found it was because `instrumentation.py` uses the cache data structure (`carbon.cache.MetricCache`) to store its own metrics, and the cache size calculation is performed after 8 other internal metrics are added to the cache. QED.

This pull request moves the calculation (& storage) of these two metrics above the other `record()` calls. It looks good on my system now, though I haven't tested it under load yet.

The code involved looks identical to me in master so this can probably get cherry-picked to both branches.
