### PR TITLE
Allow for missing storage-aggregation.conf.

### DIFF
--- a/lib/carbon/storage.py
+++ b/lib/carbon/storage.py
@@ -17,6 +17,7 @@ import whisper
 
 from os.path import join, exists, sep
 from carbon.conf import OrderedConfigParser, settings
+from carbon.exceptions import CarbonConfigException
 from carbon.util import pickle
 from carbon import log
 
@@ -151,7 +152,7 @@ def loadAggregationSchemas():
 
   try:
     config.read(STORAGE_AGGREGATION_CONFIG)
-  except CarbonConfigException:
+  except (IOError, CarbonConfigException):
     log.msg("%s not found or wrong perms, ignoring." % STORAGE_AGGREGATION_CONFIG)
 
   for section in config.sections():


### PR DESCRIPTION
The docs say that `storage-aggregation.conf` should be optional, but it's actually not!

Carbon won't start up if this file doesn't exist. Let's fix that.
