### PR TITLE
Handling MAX_CACHE_SIZE=inf in megacarbon

### DIFF
--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -176,7 +176,10 @@ class CarbonConfiguration(dict):
             raise ConfigError("%s must be either \"true\" or \"false\"" % key, filename=filename)
 
         elif valueType in (int, long, float):
-          value = valueType(value)
+          if isinstance(value, basestring) and value == "inf":
+            value = float(value)
+          else:
+            value = valueType(value)
 
         context[key] = value
 


### PR DESCRIPTION
Carrying over functionality from the whisper-based carbon branch, we need to handle cases where the user selects "inf" for MAX_CACHE_SIZE or other metrics. Current code in megacarbon borks loudly as valueType expects <type 'int'> only.
