### PR TITLE
Sample logs on dropped datapoints

### DIFF
--- a/conf/carbon.conf.example
+++ b/conf/carbon.conf.example
@@ -337,6 +337,11 @@ REPLICATION_FACTOR = 1
 # we will drop any subsequently received datapoints.
 MAX_QUEUE_SIZE = 10000
 
+# If the MAX_QUEUE_SIZE is reached and Carbon is dropping datapoints,
+# it will sample the error message at a rate of 1/LOG_SAMPLE_RATE
+# to ensure that log files do not fill up like crazy
+LOG_SAMPLE_RATE = 50
+
 # Set this to False to drop datapoints when any send queue (sending datapoints
 # to a downstream carbon daemon) hits MAX_QUEUE_SIZE. If this is True (the
 # default) then sockets over which metrics are received will temporarily stop accepting

--- a/lib/carbon/client.py
+++ b/lib/carbon/client.py
@@ -8,6 +8,7 @@ from carbon.util import pickle
 from carbon import log, state, instrumentation
 from collections import deque
 from time import time
+from random import randrange
 
 
 SEND_QUEUE_LOW_WATERMARK = settings.MAX_QUEUE_SIZE * settings.QUEUE_LOW_WATERMARK_PCT
@@ -247,6 +248,8 @@ class CarbonClientFactory(ReconnectingClientFactory):
   def sendDatapoint(self, metric, datapoint):
     instrumentation.increment(self.attemptedRelays)
     if self.queueSize >= settings.MAX_QUEUE_SIZE:
+      if randrange(0, settings.LOG_SAMPLE_RATE) == 0:
+        log.clients('%s::sendDatapoint send queue full, dropping datapoint' % self.destinationName)
       if not self.queueFull.called:
         self.queueFull.callback(self.queueSize)
       instrumentation.increment(self.fullQueueDrops)


### PR DESCRIPTION
If the MAX_QUEUE_SIZE is reached, carbon will aggressively log every dropped datapoint. This can fill up a disk rather quickly if you have a high throughput. This pull adds a setting, LOG_SAMPLE_RATE, and it samples the "dropped datapoint" logs at a rate of 1/LOG_SAMPLE_RATE.
