### PR TITLE
Reset the reconnection delay on connection

### DIFF
--- a/lib/carbon/amqp_listener.py
+++ b/lib/carbon/amqp_listener.py
@@ -151,6 +151,7 @@ class AMQPReconnectingFactory(ReconnectingClientFactory):
         self.verbose = verbose
 
     def buildProtocol(self, addr):
+        self.resetDelay()
         p = self.protocol(self.delegate, self.vhost, self.spec)
         p.factory = self
         return p


### PR DESCRIPTION
We were seeing the reconnection delay growing unbounded and never resetting after each successful reconnection. The reconnection examples here: http://twistedsphinx.funsize.net/projects/core/howto/clients.html reset the delay in their buildProtocol method. After making this change the issue went away.
