### PR TITLE
AMQP receiver reads metric from body when AMQP_METRIC_NAME_IN_BODY is True

### DIFF
--- a/lib/carbon/amqp_listener.py
+++ b/lib/carbon/amqp_listener.py
@@ -115,7 +115,7 @@ class AMQPGraphiteProtocol(AMQClient):
             if not line:
                 continue
             try:
-                if settings.get("AMQP_METRIC_NAME_IN_BODY", False):
+                if settings.get("AMQP_METRIC_NAME_IN_BODY", True):
                     metric, value, timestamp = line.split()
                 else:
                     value, timestamp = line.split()


### PR DESCRIPTION
It seems to me that if AMQP_METRIC_NAME_IN_BODY is True, we should retrieve the name of the metric from the body (and not the other way around).