### PR TITLE
Do not add values to the cache if it is full

### DIFF
--- a/lib/carbon/cache.py
+++ b/lib/carbon/cache.py
@@ -149,6 +149,9 @@ class _MetricCache(dict):
       else:
         self.size += 1
         self[metric][timestamp] = value
+    else:
+      # Updating a duplicate does not increase the cache size
+      self[metric][timestamp] = value
 
 
 # Initialize a singleton cache instance


### PR DESCRIPTION
The current implementation on megacarbon keeps adding metrics to cache if it is full. This not consistent with the documentation at is claims to drop metrics when the cache is full.

This patch ensures that the behaviour is consistent with the documentation.
