### PR TITLE
Fix regex_pattern for carbon-aggregator rules.

### DIFF
--- a/lib/carbon/aggregator/rules.py
+++ b/lib/carbon/aggregator/rules.py
@@ -124,7 +124,7 @@ class AggregationRule:
 
       regex_pattern_parts.append(regex_part)
 
-    regex_pattern = '\\.'.join(regex_pattern_parts)
+    regex_pattern = '\\.'.join(regex_pattern_parts) + '$'
     self.regex = re.compile(regex_pattern)
 
   def build_template(self):

--- a/lib/carbon/tests/test_aggregator_rules.py
+++ b/lib/carbon/tests/test_aggregator_rules.py
@@ -1,0 +1,43 @@
+import os
+import unittest
+from carbon.aggregator.rules import AggregationRule
+
+class AggregationRuleTest(unittest.TestCase):
+
+    def test_inclusive_regexes(self):
+        """
+        Test case for https://github.com/graphite-project/carbon/pull/120
+
+        Consider the two rules:
+
+        aggregated.hist.p99        (10) = avg hosts.*.hist.p99
+        aggregated.hist.p999       (10) = avg hosts.*.hist.p999
+
+        Before the abovementioned patch the second rule would be treated as
+        expected but the first rule would lead to an aggegated metric
+        aggregated.hist.p99 which would in fact be equivalent to
+        avgSeries(hosts.*.hist.p99,hosts.*.hist.p999).
+        """
+
+        method = 'avg'
+        frequency = 10
+
+        input_pattern = 'hosts.*.hist.p99'
+        output_pattern = 'aggregated.hist.p99'
+        rule99 = AggregationRule(input_pattern, output_pattern,
+                                 method, frequency)
+
+        input_pattern = 'hosts.*.hist.p999'
+        output_pattern = 'aggregated.hist.p999'
+        rule999 = AggregationRule(input_pattern, output_pattern,
+                                  method, frequency)
+
+        self.assertEqual(rule99.get_aggregate_metric('hosts.abc.hist.p99'),
+                         'aggregated.hist.p99')
+        self.assertEqual(rule99.get_aggregate_metric('hosts.abc.hist.p999'),
+                         None)
+
+        self.assertEqual(rule999.get_aggregate_metric('hosts.abc.hist.p99'),
+                         None)
+        self.assertEqual(rule999.get_aggregate_metric('hosts.abc.hist.p999'),
+                         'aggregated.hist.p999')


### PR DESCRIPTION
In its current implementation the regex_pattern would match any metric that starts with the given pattern. Consider the following rules:

```
aggregated.histogram.p99        (10) = avg hosts.*.histogram.p99
aggregated.histogram.p999       (10) = avg hosts.*.histogram.p999
```

Currently the second rule would be treated as expected but the first rule would lead to an aggegated metric `aggregated.histogram.p99` which would in fact be equivalent to `avgSeries(hosts.*.histogram.p99,hosts.*.histogram.p999)`.

This patch forces exact matches of the regex_pattern, not only prefix-matches.
