### PR TITLE
Simple security for TCP and UDP line receivers.

### DIFF
--- a/conf/carbon.conf.example
+++ b/conf/carbon.conf.example
@@ -66,6 +66,8 @@ LINE_RECEIVER_INTERFACE = 0.0.0.0
 LINE_RECEIVER_PORT = 2003
 # Set this to enable checking of a key to be set in the line receiver for simple security
 # LINE_RECEIVER_KEY = secretkey
+# By default this key is transmitted in plain text, set this to ensure it is hashed instead (more secure)
+# LINE_RECEIVER_KEY_TYPE = sha1
 
 # Set this to True to enable the UDP listener. By default this is off
 # because it is very common to run multiple carbon daemons and managing
@@ -75,6 +77,8 @@ UDP_RECEIVER_INTERFACE = 0.0.0.0
 UDP_RECEIVER_PORT = 2003
 # Set this to enable checking of a key to be set in the udp receiver for simple security
 # UDP_RECEIVER_KEY = secretkey
+# By default this key is transmitted in plain text, set this to ensure it is hashed instead (more secure)
+# UDP_RECEIVER_KEY_TYPE = sha1
 
 PICKLE_RECEIVER_INTERFACE = 0.0.0.0
 PICKLE_RECEIVER_PORT = 2004

--- a/conf/carbon.conf.example
+++ b/conf/carbon.conf.example
@@ -64,6 +64,8 @@ MAX_CREATES_PER_MINUTE = 50
 
 LINE_RECEIVER_INTERFACE = 0.0.0.0
 LINE_RECEIVER_PORT = 2003
+# Set this to enable checking of a key to be set in the line receiver for simple security
+# LINE_RECEIVER_KEY = secretkey
 
 # Set this to True to enable the UDP listener. By default this is off
 # because it is very common to run multiple carbon daemons and managing
@@ -71,6 +73,8 @@ LINE_RECEIVER_PORT = 2003
 ENABLE_UDP_LISTENER = False
 UDP_RECEIVER_INTERFACE = 0.0.0.0
 UDP_RECEIVER_PORT = 2003
+# Set this to enable checking of a key to be set in the udp receiver for simple security
+# UDP_RECEIVER_KEY = secretkey
 
 PICKLE_RECEIVER_INTERFACE = 0.0.0.0
 PICKLE_RECEIVER_PORT = 2004

--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -24,6 +24,7 @@ from ConfigParser import ConfigParser
 import whisper
 from carbon import log
 from carbon.exceptions import CarbonConfigException
+from carbon.hashing import KeyHashing
 
 from twisted.python import usage
 
@@ -547,4 +548,16 @@ def read_config(program, options, **kwargs):
             join(settings["PID_DIR"], '%s.pid' % program))
         settings["LOG_DIR"] = (options["logdir"] or settings["LOG_DIR"])
 
+
+    # Create KeyHashing objects for LINE_RECEIVER_KEY_TYPE and UDP_RECEIVER_KEY_TYPE
+    try:
+     settings["LINE_RECEIVER_KEY_TYPE"] = KeyHashing(settings["LINE_RECEIVER_KEY_TYPE"]) 
+    except KeyError:
+     settings["LINE_RECEIVER_KEY_TYPE"] = KeyHashing(None)
+
+    try:
+     settings["UDP_RECEIVER_KEY_TYPE"] = KeyHashing(settings["UDP_RECEIVER_KEY_TYPE"]) 
+    except KeyError:
+     settings["UDP_RECEIVER_KEY_TYPE"] = KeyHashing(None)
+     
     return settings

--- a/lib/carbon/protocols.py
+++ b/lib/carbon/protocols.py
@@ -75,25 +75,22 @@ class MetricLineReceiver(MetricReceiver, LineOnlyReceiver):
       key, metric, value, timestamp = line.strip().split()
       comparekey = settings.LINE_RECEIVER_KEY
       if settings.get("LINE_RECEIVER_KEY_TYPE", None):
-       if (settings.LINE_RECEIVER_KEY_TYPE == "sha1"):
+       if settings.LINE_RECEIVER_KEY_TYPE == "sha1":
         comparekey = hashlib.sha1(comparekey+timestamp).hexdigest()
-      if (key == comparekey):
+      if key == comparekey:
        datapoint = ( float(timestamp), float(value) )
        self.metricReceived(metric, datapoint)
       else:
        log.listener('invalid key in line received from client %s, ignoring' % self.peerName)
-       return
-    except:
+    except ValueError:
       log.listener('invalid line received (expecting key) from client %s, ignoring' % self.peerName)
-      return
    else:
     try:
       metric, value, timestamp = line.strip().split()
       datapoint = ( float(timestamp), float(value) )
       self.metricReceived(metric, datapoint)
-    except:
+    except ValueError:
       log.listener('invalid line received from client %s, ignoring' % self.peerName)
-      return
 
 class MetricDatagramReceiver(MetricReceiver, DatagramProtocol):
   def datagramReceived(self, data, (host, port)):
@@ -110,18 +107,15 @@ class MetricDatagramReceiver(MetricReceiver, DatagramProtocol):
          self.metricReceived(metric, datapoint)
         else:
          log.listener('invalid key in line received from client %s, ignoring' % host)
-         return
-      except:
+      except ValueError:
        log.listener('invalid line received (expecting key) from client %s, ignoring' % host)
-       return
      else:
       try:
         metric, value, timestamp = line.strip().split()
         datapoint = ( float(timestamp), float(value) )
         self.metricReceived(metric, datapoint)
-      except:
+      except ValueError:
         log.listener('invalid line received from %s, ignoring' % host)
-        return
 
 class MetricPickleReceiver(MetricReceiver, Int32StringReceiver):
   MAX_LENGTH = 2 ** 20

--- a/lib/carbon/protocols.py
+++ b/lib/carbon/protocols.py
@@ -70,23 +70,46 @@ class MetricLineReceiver(MetricReceiver, LineOnlyReceiver):
   delimiter = '\n'
 
   def lineReceived(self, line):
+   if settings.LINE_RECEIVER_KEY:
+    try:
+     key, metric, value, timestamp = line.strip().split()
+     if key == settings.LINE_RECEIVER_KEY:
+      datapoint = ( float(timestamp), float(value) )
+      self.metricReceived(metric, datapoint)
+     else:
+      log.listener('invalid key in line received from client %s, ignoring' % self.peerName)
+      return
+    except:
+     log.listener('invalid line received (expecting key) from client %s, ignoring' % self.peerName)
+     return
+   else:
     try:
       metric, value, timestamp = line.strip().split()
       datapoint = ( float(timestamp), float(value) )
+      self.metricReceived(metric, datapoint)
     except:
       log.listener('invalid line received from client %s, ignoring' % self.peerName)
       return
 
-    self.metricReceived(metric, datapoint)
-
-
 class MetricDatagramReceiver(MetricReceiver, DatagramProtocol):
   def datagramReceived(self, data, (host, port)):
     for line in data.splitlines():
+     if settings.UDP_RECEIVER_KEY:
+      try:
+        key, metric, value, timestamp = line.strip().split()
+        if key == settings.UDP_RECEIVER_KEY:
+         datapoint = ( float(timestamp), float(value) )
+         self.metricReceived(metric, datapoint)
+        else:
+         log.listener('invalid key in line received from client %s, ignoring' % host)
+         return
+      except:
+       log.listener('invalid line received (expecting key) from %s, ignoring' % host)
+       return
+     else:
       try:
         metric, value, timestamp = line.strip().split()
         datapoint = ( float(timestamp), float(value) )
-
         self.metricReceived(metric, datapoint)
       except:
         log.listener('invalid line received from %s, ignoring' % host)

--- a/lib/carbon/util.py
+++ b/lib/carbon/util.py
@@ -1,6 +1,7 @@
 import sys
 import os
 import pwd
+import hashlib
 
 from os.path import abspath, basename, dirname, join
 try:


### PR DESCRIPTION
Addition of support for a simple plaintext 'key' in the line and UDP receiver services, the presence of this key acts as a simple means to prevent unauthorised or unwanted metric sources from using these services. For better security, please consider using AMQP.

I'm currently using this in a production environment. I opted not to mangle the metric path. 