### PR TITLE
Add new type of cache query - 'cache-query-bulk' 

### DIFF
--- a/lib/carbon/protocols.py
+++ b/lib/carbon/protocols.py
@@ -163,6 +163,13 @@ class CacheManagementHandler(Int32StringReceiver):
     response = pickle.dumps(result, protocol=-1)
     self.sendString(response)
 
+  def lengthLimitExceeded(self, length):
+    """
+    because we send bulk of metrics in one request, better
+    not terminate connection if length exceed MAX_LENGTH
+    """
+    pass
+
 # Avoid import circularities
 from carbon.cache import MetricCache
 from carbon import instrumentation


### PR DESCRIPTION
Allow to query bulk of metrics in single request to Carbon
