### PR TITLE
fix setup.py install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,6 @@ setup(
   scripts=glob('bin/*'),
   package_data={ 'carbon' : ['*.xml'] },
   data_files=install_files,
-  install_requires=['twisted', 'txamqp'],
+  install_requires=['Twisted', 'txAMQP'],
   **setup_kwargs
 )


### PR DESCRIPTION
Sadly enough (at least with pip install) package names are case sensitive

setup is trying to install twisted and txamqp instead of Twisted and 
txAMQP