### PR TITLE
carbon-cache cpu usage 100% when sent metric with too big name:

### DIFF
--- a/lib/carbon/writer.py
+++ b/lib/carbon/writer.py
@@ -123,8 +123,8 @@ def writeCachedDataPoints():
         try:
           whisper.create(dbFilePath, archiveConfig, xFilesFactor, aggregationMethod, settings.WHISPER_SPARSE_CREATE, settings.WHISPER_FALLOCATE_CREATE)
           instrumentation.increment('creates')
-        except:
-          log.msg("Error creating %s" % (dbFilePath))
+        except Exception, e:
+          log.msg("Error creating %s: %s" % (dbFilePath,e))
           continue
 
       try:


### PR DESCRIPTION
https://github.com/graphite-project/carbon/issues/89
