### PR TITLE
Chown created subdirs if USER specified [backport to 0.9.x]

### DIFF
--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -249,7 +249,12 @@ class CarbonCacheOptions(usage.Options):
             elif not self.parent["nodaemon"]:
                 logdir = settings.LOG_DIR
                 if not isdir(logdir):
-                    os.makedirs(logdir)
+                    os.mkdir(logdir)
+                    if settings.USER:
+                        # We have not yet switched to the specified user,
+                        # but that user must be able to create files in this
+                        # directory.
+                        os.chown(logdir, self.parent["uid"], self.parent["gid"])
                 log.logToDir(logdir)
 
         if self["whitelist"] is None:


### PR DESCRIPTION
Requesting backport of #150 which is now on master branch, so that if a 0.9.13 is done this will work correctly for distribution packages that set USER.

In a setup with:

LOG_DIR = /var/log/carbon and the
USER    = carbon

If the --instance parameter is supplied to multiple instances of each daemon,
the daemon will create subdirectories of LOG_DIR like carbon-cache-a,
carbon-aggregator-b, etc. However, these subdirectories are owned by the
user starting the daemon, not by the USER= specified in the config file.
Only the console.log will be created, because all the other log files
are created after the daemon switches USERs.

This change makes the daemon chown() the newly-create directories to the
configured user if one is configured. To keep this simple, it now creates
only one level of directory, so you can no longer set
LOG_DIR=/path/does/not/exist and have that entire hierarchy get created.

This is related to graphite-project/carbon#149, as it a typical cause of
failing to open these log files.
