### PR TITLE
update documentation for FORWARD_ALL to reflect the default value

### DIFF
--- a/conf/carbon.conf.example
+++ b/conf/carbon.conf.example
@@ -57,7 +57,7 @@ MAX_UPDATES_PER_SECOND = 500
 # If defined, this changes the MAX_UPDATES_PER_SECOND in Carbon when a
 # stop/shutdown is initiated.  This helps when MAX_UPDATES_PER_SECOND is
 # relatively low and carbon has cached a lot of updates; it enables the carbon
-# daemon to shutdown more quickly. 
+# daemon to shutdown more quickly.
 # MAX_UPDATES_PER_SECOND_ON_SHUTDOWN = 1000
 
 # Softly limits the number of whisper files that get created each minute.
@@ -297,12 +297,12 @@ LOG_LISTENER_CONNECTIONS = True
 
 # If set true, metric received will be forwarded to DESTINATIONS in addition to
 # the output of the aggregation rules. If set false the carbon-aggregator will
-# only ever send the output of aggregation.
-FORWARD_ALL = True
+# only ever send the output of aggregation. Default value is set to false and will not forward
+FORWARD_ALL = False
 
 # Filenames of the configuration files to use for this instance of aggregator.
 # Filenames are relative to CONF_DIR.
-# 
+#
 # AGGREGATION_RULES = aggregation-rules.conf
 # REWRITE_RULES = rewrite-rules.conf
 
@@ -312,7 +312,7 @@ FORWARD_ALL = True
 # use multiple carbon-cache instances then it would look like this:
 #
 # DESTINATIONS = 127.0.0.1:2004:a, 127.0.0.1:2104:b
-# 
+#
 # The format is comma-delimited IP:PORT:INSTANCE where the :INSTANCE part is
 # optional and refers to the "None" instance if omitted.
 #


### PR DESCRIPTION
Its not clear in 0.9.12 that FORWARD_ALL is by default turned off, for the aggregator. This default behavior is not the case in 0.9.10. Updating documentation to reflect reality
