### PR TITLE
Added aggregation 'count' for carbon-aggregation-rule.

### DIFF
--- a/lib/carbon/aggregator/rules.py
+++ b/lib/carbon/aggregator/rules.py
@@ -135,12 +135,16 @@ def avg(values):
   if values:
     return float( sum(values) ) / len(values)
 
+def count(values):
+  if values:
+    return len(values)
 
 AGGREGATION_METHODS = {
-  'sum' : sum,
-  'avg' : avg,
-  'min' : min,
-  'max' : max,
+  'sum'   : sum,
+  'avg'   : avg,
+  'min'   : min,
+  'max'   : max,
+  'count' : count
 }
 
 # Importable singleton


### PR DESCRIPTION
It allows to get the number of times a metrics got pushed to the carbon aggregator.

It can be useful for instance in the case of an application pushing the execution time of every GET rest calls: apps.rest_service.GET.exec_time

```
From this metric, the aggregator can build the following metrics:
apps.rest_service.GET.call_count = count apps.rest_service.GET.exec_time
apps.rest_service.GET.avg_exec_time = avg apps.rest_service.GET.exec_time
apps.rest_service.GET.min_exec_time = min apps.rest_service.GET.exec_time
apps.rest_service.GET.max_exec_time = max apps.rest_service.GET.exec_time
```
