### PR TITLE
Change the max update on shutdown

### DIFF
--- a/lib/carbon/util.py
+++ b/lib/carbon/util.py
@@ -199,6 +199,12 @@ class TokenBucket(object):
         return True
       return False
 
+  def setCapacityAndFillRate(self, new_capacity, new_fill_rate):
+    delta = float(new_capacity) - self.capacity
+    self.capacity = float(new_capacity)
+    self.fill_rate = float(new_fill_rate)
+    self._tokens = delta + self._tokens
+
   @property
   def tokens(self):
     '''The tokens property will return the current number of tokens in the

--- a/lib/carbon/writer.py
+++ b/lib/carbon/writer.py
@@ -172,7 +172,11 @@ def reloadAggregationSchemas():
 
 def shutdownModifyUpdateSpeed():
     try:
-        settings.MAX_UPDATES_PER_SECOND = settings.MAX_UPDATES_PER_SECOND_ON_SHUTDOWN
+        shut = settings.MAX_UPDATES_PER_SECOND_ON_SHUTDOWN
+        if UPDATE_BUCKET:
+          UPDATE_BUCKET.setCapacityAndFillRate(shut,shut)
+        if CREATE_BUCKET:
+          CREATE_BUCKET.setCapacityAndFillRate(shut,shut)
         log.msg("Carbon shutting down.  Changed the update rate to: " + str(settings.MAX_UPDATES_PER_SECOND_ON_SHUTDOWN))
     except KeyError:
         log.msg("Carbon shutting down.  Update rate not changed")


### PR DESCRIPTION
The current solution only changes the global variable into another value
but it does'nt modify the TokenBucket.
This solution modifies the capacity and fill_rate of the TokenBuckets
CREATE_BUCKET and UPDATE_BUCKET into the value defined in the settings
so that the shutdown will be faster

Resolves issue #151
