### PR TITLE
fixed replication

### DIFF
--- a/lib/carbon/hashing.py
+++ b/lib/carbon/hashing.py
@@ -47,6 +47,7 @@ class ConsistentHashRing:
   def get_nodes(self, key):
     assert self.ring
     nodes = set()
+    uniq_nodes = []
     position = self.compute_ring_position(key)
     search_entry = (position, None)
     index = bisect.bisect_left(self.ring, search_entry) % self.ring_len
@@ -55,8 +56,9 @@ class ConsistentHashRing:
     while nodes_len < self.nodes_len and index != last_index:
       next_entry = self.ring[index]
       (position, next_node) = next_entry
-      if next_node not in nodes:
+      if next_node[0] not in uniq_nodes:
         nodes.add(next_node)
+        uniq_nodes.append(next_node[0])
         yield next_node
 
       index = (index + 1) % len(self.ring)


### PR DESCRIPTION
Replication is broken. The destinaion for metric (number of destinations is REPLICATION_FACTOR) is choosed by host:instance, but should be choosed only by host. 
Without this patch not all metrics replicated to second host. 
