### PR TITLE
Aggregation rules now search for exact regular expression pattern matches

### DIFF
--- a/conf/carbon.conf.example
+++ b/conf/carbon.conf.example
@@ -379,3 +379,7 @@ MAX_AGGREGATION_INTERVALS = 5
 # In order to turn off logging of successful connections for the line
 # receiver, set this to False
 # LOG_LISTENER_CONN_SUCCESS = True
+
+# In order to turn off logging of metrics with no corresponding
+# aggregation rules receiver, set this to False
+# LOG_AGGREGATOR_MISSES = False

--- a/lib/carbon/aggregator/receiver.py
+++ b/lib/carbon/aggregator/receiver.py
@@ -2,6 +2,7 @@ from carbon.instrumentation import increment
 from carbon.aggregator.rules import RuleManager
 from carbon.aggregator.buffers import BufferManager
 from carbon.rewrite import RewriteRuleManager
+from carbon.conf import settings
 from carbon import events, log
 
 
@@ -34,5 +35,5 @@ def process(metric, datapoint):
   if metric not in aggregate_metrics:
     events.metricGenerated(metric, datapoint)
 
-  if len(aggregate_metrics) == 0:
+  if settings.LOG_AGGREGATOR_MISSES and len(aggregate_metrics) == 0:
     log.msg("Couldn't match metric %s with any aggregation rule. Passing on un-aggregated." % metric)

--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -75,6 +75,7 @@ defaults = dict(
   MIN_RESET_INTERVAL=121,
   USE_RATIO_RESET=False,
   LOG_LISTENER_CONN_SUCCESS=True,
+  LOG_AGGREGATOR_MISSES=True,
   AGGREGATION_RULES='aggregation-rules.conf',
   REWRITE_RULES='rewrite-rules.conf',
   RELAY_RULES='relay-rules.conf',


### PR DESCRIPTION
We were experiencing an issue in which p99 values were being skewed by p999 values. We had the following aggregation rules:

production.all.response_time.p99 (10)   = max production.host.*.response_time.p99
production.all.response_time.p999 (10) = max production.host.*.response_time.p999

Our experience was that the aggregated p999 metric values matched the per host p999 metric values. However, the aggregated p99 metric values were considerably higher than the per host p99 metric values. In essence, the p99 and p999 metric values were being clubbed together.

With this code change, the aggregation rules will look for exact pattern matches.

- if it's p99: p99 does match, p999 doesn't match
- if it's p999: p99 doesn't match, p999 matches