### PR TITLE
require twisted 13.1.0, since 13.2.0 broke backward compatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,6 @@ setup(
   scripts=glob('bin/*'),
   package_data={ 'carbon' : ['*.xml'] },
   data_files=install_files,
-  install_requires=['twisted', 'txamqp'],
+  install_requires=['twisted == 13.1.0', 'txamqp'],
   **setup_kwargs
 )


### PR DESCRIPTION
I got this error with 13.2.0

```
root@integration:/etc/nagios/nrpe.d# service carbon-cache-0 start
Traceback (most recent call last):
  File "/usr/local/graphite/bin/carbon-cache.py", line 28, in <module>
    from carbon.util import run_twistd_plugin
  File "/usr/local/graphite/local/lib/python2.7/site-packages/carbon/util.py", line 21, in <module>
    from twisted.scripts._twistd_unix import daemonize
ImportError: cannot import name daemonize

```

Switched to 13.1.0, it worked normal.
