### PR TITLE
remove daemonize for compatability with twisted 13.2.0

### DIFF
--- a/lib/carbon/util.py
+++ b/lib/carbon/util.py
@@ -16,10 +16,6 @@ except:
 
 from twisted.python.util import initgroups
 from twisted.scripts.twistd import runApp
-from twisted.scripts._twistd_unix import daemonize
-
-
-daemonize = daemonize # Backwards compatibility
 
 
 def dropprivs(user):


### PR DESCRIPTION
Alternative solution for:

https://github.com/graphite-project/carbon/pull/180

Been running this version for a while and it behaves fine.

This one if for master, do you want one for `0.9.x` too? Not sure if it will work.
