### PR TITLE
Try adding a signal handler outside of twisted to catch HUP.

### DIFF
--- a/lib/carbon/util.py
+++ b/lib/carbon/util.py
@@ -1,6 +1,7 @@
 import sys
 import os
 import pwd
+import log
 
 from os.path import abspath, basename, dirname, join
 try:
@@ -13,6 +14,12 @@ try:
 except:
   import pickle
   USING_CPICKLE = False
+
+try:
+  import signal
+except ImportError:
+  log.debug("Couldn't import signal")
+
 
 from twisted.python.util import initgroups
 from twisted.scripts.twistd import runApp
@@ -27,6 +34,10 @@ def dropprivs(user):
 
 
 def run_twistd_plugin(filename):
+    if 'signal' in globals().keys():
+      log.debug("Installing SIG_IGN for SIGHUP")
+      signal.signal(signal.SIGHUP, signal.SIG_IGN)
+
     from carbon.conf import get_parser
     from twisted.scripts.twistd import ServerOptions
 
@@ -151,11 +162,11 @@ else:
       if not name in self.PICKLE_SAFE[module]:
         raise pickle.UnpicklingError('Attempting to unpickle unsafe class %s' % name)
       return getattr(mod, name)
- 
+
     @classmethod
     def loads(cls, pickle_string):
       return cls(StringIO(pickle_string)).load()
- 
+
 
 def get_unpickler(insecure=False):
   if insecure:


### PR DESCRIPTION
This ignores HUP.  We can see about re-reading the config at a later
date.
