### PR TITLE
Restore recursive mkdir on LOG_DIR

### DIFF
--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -251,7 +251,7 @@ class CarbonCacheOptions(usage.Options):
             elif not self.parent["nodaemon"]:
                 logdir = settings.LOG_DIR
                 if not isdir(logdir):
-                    os.mkdir(logdir)
+                    os.makedirs(logdir)
                     if settings.USER:
                         # We have not yet switched to the specified user,
                         # but that user must be able to create files in this


### PR DESCRIPTION
Revert part of 2bcd901a9e60f24a4c1c972bc3354969a8c8258e.
Up to three levels of directories may need to be created, if a user only
defines STORAGE_DIR and uses the --instance parameter.

Now, if you want every subdir under LOG_DIR to be owned by USER, you
must create all but the last directory beforehand and give it the
correct owner. Automatically chown()'ing each level of directory created
would have been too complicated.

Fixes #199.
