### PR TITLE
Document the fact that one can use regexps in the aggregation-rules.

### DIFF
--- a/conf/aggregation-rules.conf.example
+++ b/conf/aggregation-rules.conf.example
@@ -32,4 +32,12 @@
 #
 #   <env>.applications.<app>.all.<app_metric> (60) = sum <env>.applications.<app>.*.<<app_metric>>
 #
+# It is also possible to use regular expressions. Following the example above
+# when using:
+#
+#   <env>.applications.<app>.<domain>.requests (60) = sum <env>.applications.<app>.<domain>\d{2}.requests
+#
+# You will end up with 'prod.applications.apache.www.requests' instead of
+# 'prod.applications.apache.all.requests'.
+#
 # Note that any time this file is modified, it will be re-read automatically.


### PR DESCRIPTION
The fact that one can use regexps in aggregation-rules patterns is currently not documented but very useful.
