### PR TITLE
Pluggable storage engines for carbon

### DIFF
--- a/conf/carbon.conf.example
+++ b/conf/carbon.conf.example
@@ -29,6 +29,8 @@
 #   PID_DIR        = /var/run/
 #
 #LOCAL_DATA_DIR = /opt/graphite/storage/whisper/
+# initializes graphitedata plugin DB
+# DB_INIT_FUNC=graphitedata.plugin.WhisperDB
 
 # Specify the user to drop privileges to
 # If this is blank carbon runs as the user that invokes it
@@ -172,6 +174,7 @@ WHISPER_AUTOFLUSH = False
 
 # To configure special settings for the carbon-cache instance 'b', uncomment this:
 #[cache:b]
+# DB_INIT_FUNC=graphitedata.plugin.WhisperDB
 #LINE_RECEIVER_PORT = 2103
 #PICKLE_RECEIVER_PORT = 2104
 #CACHE_QUERY_PORT = 7102

--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -78,6 +78,7 @@ defaults = dict(
   AGGREGATION_RULES='aggregation-rules.conf',
   REWRITE_RULES='rewrite-rules.conf',
   RELAY_RULES='relay-rules.conf',
+  DB_INIT_FUNC="carbon.db.NewWhisperDB",
 )
 
 

--- a/lib/carbon/db.py
+++ b/lib/carbon/db.py
@@ -1,0 +1,56 @@
+import importlib
+import whisper
+from os.path import sep, dirname, join, exists
+from os import makedirs
+from carbon.conf import settings
+
+
+class WhisperDB(object):
+  """
+  WhisperDB is the default Whisper database implementation for the 
+  pluggable storage system.
+  """
+  __slots__ = ('dataDir')
+
+  def __init__(self, dataDir):
+    self.dataDir = dataDir
+
+  def __getFilesystemPath(self, metric):
+    metric_path = metric.replace('.', sep).lstrip(sep) + '.wsp'
+    return join(self.dataDir, metric_path)
+
+  def info(self, metric):
+    return whisper.info(self.__getFilesystemPath(metric))
+
+  def setAggregationMethod(self, metric, aggregationMethod, xFilesFactor=None):
+    return whisper.setAggregationMethod(self.__getFilesystemPath(metric), aggregationMethod, xFilesFactor)
+
+  def create(self, metric, retention_config, xFilesFactor=None, aggregationMethod=None, sparse=False, useFallocate=False):
+    dbFilePath = self.__getFilesystemPath(metric)
+    dbDir = dirname(dbFilePath)
+
+    try:
+      if not (exists(dbDir)):
+        makedirs(dbDir, 0755)
+    except Exception as e:
+      print("Error creating dir " + dbDir + " : " + e)
+    return whisper.create(dbFilePath, retention_config, xFilesFactor, aggregationMethod, sparse, useFallocate)
+
+  def update_many(self, metric, datapoints, retention_config):
+    ''' We pass the retention_config so that the API supports it. Whisper silently ignores it. '''
+    return whisper.update_many(self.__getFilesystemPath(metric), datapoints)
+
+  def exists(self, metric):
+    return exists(self.__getFilesystemPath(metric))
+
+def NewWhisperDB():
+  return WhisperDB(settings.LOCAL_DATA_DIR)
+
+def get_db(initFunc):
+  module_name, class_name = initFunc.rsplit('.', 1)
+  module = importlib.import_module(module_name)
+  return getattr(module, class_name)()
+
+# application database
+
+APP_DB = get_db(settings.DB_INIT_FUNC)

--- a/lib/carbon/management.py
+++ b/lib/carbon/management.py
@@ -1,17 +1,14 @@
 import traceback
-import whisper
 from carbon import log
-from carbon.storage import getFilesystemPath
-
+from carbon.db import APP_DB
 
 
 def getMetadata(metric, key):
   if key != 'aggregationMethod':
     return dict(error="Unsupported metadata key \"%s\"" % key)
 
-  wsp_path = getFilesystemPath(metric)
   try:
-    value = whisper.info(wsp_path)['aggregationMethod']
+    value = APP_DB.info(metric)['aggregationMethod']
     return dict(value=value)
   except:
     log.err()
@@ -21,10 +18,8 @@ def getMetadata(metric, key):
 def setMetadata(metric, key, value):
   if key != 'aggregationMethod':
     return dict(error="Unsupported metadata key \"%s\"" % key)
-
-  wsp_path = getFilesystemPath(metric)
   try:
-    old_value = whisper.setAggregationMethod(wsp_path, value)
+    old_value = APP_DB.setAggregationMethod(metric, value)
     return dict(old_value=old_value, new_value=value)
   except:
     log.err()

--- a/lib/carbon/storage.py
+++ b/lib/carbon/storage.py
@@ -15,7 +15,7 @@ limitations under the License."""
 import os, re
 import whisper
 
-from os.path import join, exists, sep
+from os.path import join, exists
 from carbon.conf import OrderedConfigParser, settings
 from carbon.exceptions import CarbonConfigException
 from carbon.util import pickle
@@ -25,10 +25,6 @@ from carbon import log
 STORAGE_SCHEMAS_CONFIG = join(settings.CONF_DIR, 'storage-schemas.conf')
 STORAGE_AGGREGATION_CONFIG = join(settings.CONF_DIR, 'storage-aggregation.conf')
 STORAGE_LISTS_DIR = join(settings.CONF_DIR, 'lists')
-
-def getFilesystemPath(metric):
-  metric_path = metric.replace('.',sep).lstrip(sep) + '.wsp'
-  return join(settings.LOCAL_DATA_DIR, metric_path)
 
 
 class Schema:
@@ -40,7 +36,6 @@ class Schema:
 
 
 class DefaultSchema(Schema):
-
   def __init__(self, name, archives):
     self.name = name
     self.archives = archives
@@ -50,7 +45,6 @@ class DefaultSchema(Schema):
 
 
 class PatternSchema(Schema):
-
   def __init__(self, name, pattern, archives):
     self.name = name
     self.pattern = pattern
@@ -62,7 +56,6 @@ class PatternSchema(Schema):
 
 
 class ListSchema(Schema):
-
   def __init__(self, name, listName, archives):
     self.name = name
     self.listName = listName
@@ -71,9 +64,9 @@ class ListSchema(Schema):
 
     if exists(self.path):
       self.mtime = os.stat(self.path).st_mtime
-      fh = open(self.path, 'rb')
-      self.members = pickle.load(fh)
-      fh.close()
+      file_handle = open(self.path, 'rb')
+      self.members = pickle.load(file_handle)
+      file_handle.close()
 
     else:
       self.mtime = 0
@@ -93,8 +86,7 @@ class ListSchema(Schema):
 
 
 class Archive:
-
-  def __init__(self,secondsPerPoint,points):
+  def __init__(self, secondsPerPoint, points):
     self.secondsPerPoint = int(secondsPerPoint)
     self.points = int(points)
 
@@ -102,7 +94,7 @@ class Archive:
     return "Archive = (Seconds per point: %d, Datapoints to save: %d)" % (self.secondsPerPoint, self.points) 
 
   def getTuple(self):
-    return (self.secondsPerPoint,self.points)
+    return (self.secondsPerPoint, self.points)
 
   @staticmethod
   def fromString(retentionDef):


### PR DESCRIPTION
Based on jbooth's  minimalist db plugin for carbon, (https://github.com/graphite-project/carbon/pull/210)

From jbooth:
" so that it can record to other storage engines besides whisper, just as graphite-web can pull up other finders besides the StandardFinder. It has 5 methods:

info
setAggregationMethod
create
update_many
exists

and is configured by a single config variable, DB_INIT_FUNC, which should be a visible function that yields an object fulfilling the above contract.

I've got an example plugin for Hbase at https://github.com/posix4e/graphite-data --  -- we could add other storage engines to that repo and I'd be happy to contribute the whole repo over to graphite-project as well. "

I rebased it to a single patch and will track master.