### PR TITLE
Fix aggregator replication factor setting

### DIFF
--- a/lib/carbon/service.py
+++ b/lib/carbon/service.py
@@ -149,7 +149,7 @@ def createAggregatorService(config):
     root_service = createBaseService(config)
 
     # Configure application components
-    router = ConsistentHashingRouter()
+    router = ConsistentHashingRouter(settings.REPLICATION_FACTOR)
     client_manager = CarbonClientManager(router)
     client_manager.setServiceParent(root_service)
 


### PR DESCRIPTION
Though defined in the example carbon.conf, replication factor is not being used for the aggregator service.  This updates the aggregator router to use the setting.
