### PR TITLE
Added the option to specify the minimum number of datapoints per update operation

### DIFF
--- a/conf/carbon.conf.example
+++ b/conf/carbon.conf.example
@@ -63,6 +63,17 @@ MAX_UPDATES_PER_SECOND = 500
 # the files quickly but at the risk of slowing I/O down considerably for a while.
 MAX_CREATES_PER_MINUTE = 50
 
+# The datapoints for a metric would be written to disk only if the number of
+# datapoints in memory for that metric is greater than or equal to MIN_DATAPOINTS_PER_UPDATE. 
+# However this constraint is lifted if the cache size grows beyond LOW_CACHE_SIZE.
+# Default value is 1. Increase it to get a more predictable write pattern across multiple 
+# carbon-cache instances i.e. every carbon-cache instance getting a share of disk I/O.
+# It helps in avoiding a large a number of small disk-writes as well.
+# The default value for LOW_CACHE_SIZE is 80% of MAX_CACHE_SIZE   
+MIN_DATAPOINTS_PER_UPDATE = 1
+LOW_CACHE_SIZE = inf
+
+
 LINE_RECEIVER_INTERFACE = 0.0.0.0
 LINE_RECEIVER_PORT = 2003
 

--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -31,6 +31,7 @@ from twisted.python import usage
 defaults = dict(
   USER="",
   MAX_CACHE_SIZE=float('inf'),
+  LOW_CACHE_SIZE=float('inf'),
   MAX_UPDATES_PER_SECOND=500,
   MAX_CREATES_PER_MINUTE=float('inf'),
   LINE_RECEIVER_INTERFACE='0.0.0.0',
@@ -78,6 +79,7 @@ defaults = dict(
   AGGREGATION_RULES='aggregation-rules.conf',
   REWRITE_RULES='rewrite-rules.conf',
   RELAY_RULES='relay-rules.conf',
+  MIN_DATAPOINTS_PER_UPDATE=1,
 )
 
 


### PR DESCRIPTION
Motivation:
1.) Avoid a large a number of small disk-writes.
2.) A more predictable write pattern across multiple carbon-cache instances i.e. every carbon-cache instance getting a share of disk I/O.

Modifications to meet the above points:
Modified writer.py to make carbon-cache do a whisper.update_many() only for those metrics which have more than MIN_DATAPOINTS_PER_UPDATE datapoints in cache. And this constraint is removed when the cache size grows above LOW_CACHE_SIZE, and comes back into effect when cache size shrinks below LOW_CACHE_SIZE.
LOW_CACHE_SIZE is set to 80% of MAX_CACHE_SIZE by default.
