### PR TITLE
Enhanced rebased #140

### DIFF
--- a/conf/carbon.conf.example
+++ b/conf/carbon.conf.example
@@ -381,3 +381,7 @@ MAX_AGGREGATION_INTERVALS = 5
 # In order to turn off logging of successful connections for the line
 # receiver, set this to False
 # LOG_LISTENER_CONN_SUCCESS = True
+#
+# In order to enable logging of metrics with no corresponding aggregation rules
+# receiver, set this to True
+# LOG_AGGREGATOR_MISSES = False

--- a/lib/carbon/aggregator/receiver.py
+++ b/lib/carbon/aggregator/receiver.py
@@ -2,6 +2,7 @@ from carbon.instrumentation import increment
 from carbon.aggregator.rules import RuleManager
 from carbon.aggregator.buffers import BufferManager
 from carbon.rewrite import RewriteRuleManager
+from carbon.conf import settings
 from carbon import events, log
 
 
@@ -32,5 +33,6 @@ def process(metric, datapoint):
     metric = rule.apply(metric)
 
   if metric not in aggregate_metrics:
-    log.msg("Couldn't match metric %s with any aggregation rule. Passing on un-aggregated." % metric)
+    if settings.LOG_AGGREGATOR_MISSES:
+      log.msg("Couldn't match metric %s with any aggregation rule. Passing on un-aggregated." % metric)
     events.metricGenerated(metric, datapoint)

--- a/lib/carbon/aggregator/receiver.py
+++ b/lib/carbon/aggregator/receiver.py
@@ -13,14 +13,15 @@ def process(metric, datapoint):
     metric = rule.apply(metric)
 
   aggregate_metrics = []
+  aggregated = False
 
   for rule in RuleManager.rules:
     aggregate_metric = rule.get_aggregate_metric(metric)
 
     if aggregate_metric is None:
       continue
-    else:
-      aggregate_metrics.append(aggregate_metric)
+    aggregate_metrics.append(aggregate_metric)
+    aggregated = True
 
     buffer = BufferManager.get_buffer(aggregate_metric)
 
@@ -33,6 +34,6 @@ def process(metric, datapoint):
     metric = rule.apply(metric)
 
   if metric not in aggregate_metrics:
-    if settings.LOG_AGGREGATOR_MISSES:
+    if settings.LOG_AGGREGATOR_MISSES and not aggregated:
       log.msg("Couldn't match metric %s with any aggregation rule. Passing on un-aggregated." % metric)
     events.metricGenerated(metric, datapoint)

--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -78,6 +78,7 @@ defaults = dict(
   AGGREGATION_RULES='aggregation-rules.conf',
   REWRITE_RULES='rewrite-rules.conf',
   RELAY_RULES='relay-rules.conf',
+  LOG_AGGREGATOR_MISSES=False,
 )
 
 


### PR DESCRIPTION
Merge request #140 (add a setting to inhibit diagnostics when forwarding metrics) no longer applied cleanly; the first commit updates it.

The second commit corrects the test so the diagnostic is provided only when the original metric did not contribute to an aggregation, and not in the much more common case when it was not clobbered by an aggregate metric.