### PR TITLE
Fix aggregated metrics

### DIFF
--- a/lib/carbon/cache.py
+++ b/lib/carbon/cache.py
@@ -62,7 +62,10 @@ class _MetricCache(defaultdict):
       datapoints = self.popitem()
     elif not metric and self.method == "sorted":
       metric = self.queue.next()
-      datapoints = (metric, super(_MetricCache, self).pop(metric))
+      # Save only last value for each timestamp
+      popped = super(_MetricCache, self).pop(metric)
+      ordered = sorted(dict(popped).items(), key=lambda x: x[0])
+      datapoints = (metric, deque(ordered))
     self.size -= len(datapoints[1])
     return datapoints
 

--- a/lib/carbon/tests/test_cache.py
+++ b/lib/carbon/tests/test_cache.py
@@ -30,8 +30,9 @@ class MetricCacheIntegrity(MockerTestCase):
         datapoint1 = (now - 10, float(1))
         datapoint2 = (now, float(2))
         MetricCache.store("d.e.f", datapoint1)
-        MetricCache.store("a.b.c", datapoint1)
+        # Simulate metrics arriving out of time
         MetricCache.store("a.b.c", datapoint2)
+        MetricCache.store("a.b.c", datapoint1)
 
         (m, d) = MetricCache.pop()
         self.assertEqual(("a.b.c", deque([datapoint1, datapoint2])), (m, d))


### PR DESCRIPTION
This is a pull request for issue graphite-project/carbon#109 .

The problem has also been [described on stackoverflow](http://stackoverflow.com/questions/19133350/graphite-metrics-from-aggregator-showing-weird-retention-behaviour). The suggested fix fixes the problem for me. It would be great if it could be included as this issue renders `carbon-aggregator` rather useless.
