### PR TITLE
Fix crashes due to auto-type in Python

### DIFF
--- a/lib/carbon/instrumentation.py
+++ b/lib/carbon/instrumentation.py
@@ -122,13 +122,13 @@ class InstrumentationService(Service):
           events.metricGenerated(metric_path, datapoint)
 
       else: # counters
-        metric_path = self.metric_prefix + metric
+        metric_path = self.metric_prefix + str(metric)
         datapoint = (now, data)
         events.metricGenerated(metric_path, datapoint)
 
     # metric functions
     for metric, func in metric_functions.items():
-      metric_path = self.metric_prefix + metric
+      metric_path = self.metric_prefix + str(metric)
       try:
         value = func()
       except:

--- a/plugins/maintenance/defrag.py
+++ b/plugins/maintenance/defrag.py
@@ -9,7 +9,7 @@ namespace = globals()
 for p in ('maxSlicesPerNode', 'maxSliceGap', 'mode'):
   if p not in params:
     raise MissingRequiredParam(p)
-  value = params.pop(p)
+  value = str(params.pop(p))
   if value.isdigit():
     value = int(value)
   namespace[p] = value


### PR DESCRIPTION
These two commits do fix crashes caused by auto-type feature in Python. We expect instance of one type, however Python automatically creates instance of int/str which doesn't have or isn't capable of wanted operations.