### PR TITLE
Don't hard-code the install path

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,3 @@
-[install]
-prefix = /opt/graphite
-install-lib = %(prefix)s/lib
-
 [bdist_rpm]
 requires = python-twisted
            whisper


### PR DESCRIPTION
This breaks virtualenv, non-root installs, etc. 

See #173, #74, #128, #221
