### PR TITLE
Use the RedHat init scripts on CentOS, too

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ conf_files = [ ('conf', glob('conf/*.example')) ]
 
 install_files = storage_dirs + conf_files
 
-# If we are building on RedHat, let's use the redhat init scripts.
-if platform.dist()[0] == 'redhat':
+# If we are building on RedHat/CentOS, let's use the redhat init scripts.
+if platform.dist()[0] in ('redhat', 'centos'):
     init_scripts = [ ('/etc/init.d', ['distro/redhat/init.d/carbon-cache',
                                       'distro/redhat/init.d/carbon-relay',
                                       'distro/redhat/init.d/carbon-aggregator']) ]


### PR DESCRIPTION
Because CentOS is based on RHEL, it makes sense to use the RedHat init scripts on CentOS, too.