### PR TITLE
Update lib/carbon/writer.py (0.9.x)

### DIFF
--- a/lib/carbon/writer.py
+++ b/lib/carbon/writer.py
@@ -107,7 +107,7 @@ def writeCachedDataPoints():
         dbDir = dirname(dbFilePath)
         try:
             if not exists(dbDir):
-                os.makedirs(dbDir, 0755)
+                os.makedirs(dbDir)
         except OSError, e:
             log.err("%s" % e)
         log.creates("creating database file %s (archive=%s xff=%s agg=%s)" %


### PR DESCRIPTION
Creating the directory tree with the proper umask/permissions in the environment. The new value of the umask will come from the Twisted parameter --umask. The permissions will now match the whisper archives.

Just backported https://github.com/graphite-project/carbon/pull/69 to 0.9.x.
