### PR TITLE
Only add handlers for pausing/resuming metric receipt when USE_FLOW_CONTROL is enabled

### DIFF
--- a/lib/carbon/protocols.py
+++ b/lib/carbon/protocols.py
@@ -23,8 +23,9 @@ class MetricReceiver:
       self.pauseReceiving()
 
     state.connectedMetricReceiverProtocols.add(self)
-    events.pauseReceivingMetrics.addHandler(self.pauseReceiving)
-    events.resumeReceivingMetrics.addHandler(self.resumeReceiving)
+    if settings.USE_FLOW_CONTROL:
+      events.pauseReceivingMetrics.addHandler(self.pauseReceiving)
+      events.resumeReceivingMetrics.addHandler(self.resumeReceiving)
 
   def getPeerName(self):
     if hasattr(self.transport, 'getPeer'):
@@ -48,8 +49,9 @@ class MetricReceiver:
       log.listener("%s connection with %s lost: %s" % (self.__class__.__name__, self.peerName, reason.value))
 
     state.connectedMetricReceiverProtocols.remove(self)
-    events.pauseReceivingMetrics.removeHandler(self.pauseReceiving)
-    events.resumeReceivingMetrics.removeHandler(self.resumeReceiving)
+    if settings.USE_FLOW_CONTROL:
+      events.pauseReceivingMetrics.removeHandler(self.pauseReceiving)
+      events.resumeReceivingMetrics.removeHandler(self.resumeReceiving)
 
   def metricReceived(self, metric, datapoint):
     if BlackList and metric in BlackList:


### PR DESCRIPTION
MetricReceiver calls `addHandler` twice per incoming metric connection; `addHandler` is a fairly expensive method which is O(n) in the number of registered handlers (since it walks through an array of **every** registered handler). We profiled our very busy carbon-caches with cProfile and found that the addHandler calls were something like 4% of our total CPU time, and were sort of pointless because we have flow control disabled.

This patch gets rid of the pauseReceivingMetrics handlers when USE_FLOW_CONTROL is disabled and gets addHandler out of our cProfiles. Obviously, 4% is a pretty negligable perf improvement, but it seemed worth upstreaming anyway.
