### PR TITLE
Get rid of bare "except:" calls

### DIFF
--- a/lib/carbon/aggregator/rules.py
+++ b/lib/carbon/aggregator/rules.py
@@ -29,7 +29,7 @@ class RuleManager:
     # Only read if the rules file has been modified
     try:
       mtime = getmtime(self.rules_file)
-    except:
+    except Exception:
       log.err("Failed to get mtime of %s" % self.rules_file)
       return
     if mtime <= self.rules_last_read:
@@ -59,7 +59,7 @@ class RuleManager:
       frequency = int( frequency.lstrip('(').rstrip(')') )
       return AggregationRule(input_pattern, output_pattern, method, frequency)
 
-    except:
+    except Exception:
       log.err("Failed to parse line: %s" % line)
       raise
 
@@ -90,7 +90,7 @@ class AggregationRule:
       extracted_fields = match.groupdict()
       try:
         result = self.output_template % extracted_fields
-      except:
+      except Exception:
         log.err("Failed to interpolate template %s with fields %s" % (self.output_template, extracted_fields))
 
     self.cache[metric_path] = result

--- a/lib/carbon/amqp_listener.py
+++ b/lib/carbon/amqp_listener.py
@@ -44,7 +44,7 @@ import txamqp.spec
 
 try:
     import carbon
-except:
+except ImportError:
     # this is being run directly, carbon is not installed
     LIB_DIR = os.path.dirname(os.path.dirname(__file__))
     sys.path.insert(0, LIB_DIR)

--- a/lib/carbon/amqp_publisher.py
+++ b/lib/carbon/amqp_publisher.py
@@ -101,7 +101,7 @@ def main():
       else:
         timestamp = time.time()
 
-    except:
+    except Exception:
       parser.print_usage()
       raise SystemExit(1)
 

--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -157,10 +157,10 @@ class Settings(dict):
         # Attempt to figure out numeric types automatically
         try:
           value = int(value)
-        except:
+        except Exception:
           try:
             value = float(value)
-          except:
+          except Exception:
             pass
 
       self[key] = value
@@ -294,7 +294,7 @@ class CarbonCacheOptions(usage.Options):
             try:
                 pid = int(pf.read().strip())
                 pf.close()
-            except:
+            except Exception:
                 print "Could not read pidfile %s" % pidfile
                 raise SystemExit(1)
             print "Sending kill signal to pid %d" % pid
@@ -316,7 +316,7 @@ class CarbonCacheOptions(usage.Options):
             try:
                 pid = int(pf.read().strip())
                 pf.close()
-            except:
+            except Exception:
                 print "Failed to read pid from %s" % pidfile
                 raise SystemExit(1)
 
@@ -334,7 +334,7 @@ class CarbonCacheOptions(usage.Options):
                 try:
                     pid = int(pf.read().strip())
                     pf.close()
-                except:
+                except Exception:
                     print "Could not read pidfile %s" % pidfile
                     raise SystemExit(1)
                 if _process_alive(pid):
@@ -345,7 +345,7 @@ class CarbonCacheOptions(usage.Options):
                     print "Removing stale pidfile %s" % pidfile
                     try:
                         os.unlink(pidfile)
-                    except:
+                    except Exception:
                         print "Could not remove pidfile %s" % pidfile
 
             print "Starting %s (instance %s)" % (program, instance)

--- a/lib/carbon/events.py
+++ b/lib/carbon/events.py
@@ -18,7 +18,7 @@ class Event:
     for handler in self.handlers:
       try:
         handler(*args, **kwargs)
-      except:
+      except Exception:
         log.err(None, "Exception in %s event handler: args=%s kwargs=%s" % (self.name, args, kwargs))
 
 

--- a/lib/carbon/instrumentation.py
+++ b/lib/carbon/instrumentation.py
@@ -143,7 +143,7 @@ def recordMetrics():
 
   try: # This only works on Linux
     record('memUsage', getMemUsage())
-  except:
+  except Exception:
     pass
 
 

--- a/lib/carbon/management.py
+++ b/lib/carbon/management.py
@@ -13,7 +13,7 @@ def getMetadata(metric, key):
   try:
     value = whisper.info(wsp_path)['aggregationMethod']
     return dict(value=value)
-  except:
+  except Exception:
     log.err()
     return dict(error=traceback.format_exc())
 
@@ -26,6 +26,6 @@ def setMetadata(metric, key, value):
   try:
     old_value = whisper.setAggregationMethod(wsp_path, value)
     return dict(old_value=old_value, new_value=value)
-  except:
+  except Exception:
     log.err()
     return dict(error=traceback.format_exc())

--- a/lib/carbon/protocols.py
+++ b/lib/carbon/protocols.py
@@ -73,7 +73,7 @@ class MetricLineReceiver(MetricReceiver, LineOnlyReceiver):
     try:
       metric, value, timestamp = line.strip().split()
       datapoint = ( float(timestamp), float(value) )
-    except:
+    except Exception:
       log.listener('invalid line received from client %s, ignoring' % self.peerName)
       return
 
@@ -88,7 +88,7 @@ class MetricDatagramReceiver(MetricReceiver, DatagramProtocol):
         datapoint = ( float(timestamp), float(value) )
 
         self.metricReceived(metric, datapoint)
-      except:
+      except Exception:
         log.listener('invalid line received from %s, ignoring' % host)
 
 
@@ -102,14 +102,14 @@ class MetricPickleReceiver(MetricReceiver, Int32StringReceiver):
   def stringReceived(self, data):
     try:
       datapoints = self.unpickler.loads(data)
-    except:
+    except Exception:
       log.listener('invalid pickle received from %s, ignoring' % self.peerName)
       return
 
     for (metric, datapoint) in datapoints:
       try:
         datapoint = ( float(datapoint[0]), float(datapoint[1]) ) #force proper types
-      except:
+      except Exception:
         continue
 
       self.metricReceived(metric, datapoint)

--- a/lib/carbon/regexlist.py
+++ b/lib/carbon/regexlist.py
@@ -27,7 +27,7 @@ class RegexList:
 
     try:
       mtime = os.path.getmtime(self.list_file)
-    except:
+    except Exception:
       log.err("Failed to get mtime of %s" % self.list_file)
       return
 
@@ -42,7 +42,7 @@ class RegexList:
         continue
       try:
         new_regex_list.append(re.compile(pattern))
-      except:
+      except Exception:
         log.err("Failed to parse '%s' in '%s'. Ignoring line" % (pattern, self.list_file))
 
     self.regex_list = new_regex_list

--- a/lib/carbon/rewrite.py
+++ b/lib/carbon/rewrite.py
@@ -29,7 +29,7 @@ class RewriteRuleManager:
     # Only read if the rules file has been modified
     try:
       mtime = getmtime(self.rules_file)
-    except:
+    except Exception:
       log.err("Failed to get mtime of %s" % self.rules_file)
       return
     if mtime <= self.rules_last_read:

--- a/lib/carbon/storage.py
+++ b/lib/carbon/storage.py
@@ -170,7 +170,7 @@ def loadAggregationSchemas():
         assert 0 <= xFilesFactor <= 1
       if aggregationMethod is not None:
         assert aggregationMethod in whisper.aggregationMethods
-    except:
+    except Exception:
       log.msg("Invalid schemas found in %s." % section )
       continue
 

--- a/lib/carbon/util.py
+++ b/lib/carbon/util.py
@@ -10,7 +10,7 @@ except ImportError:
 try:
   import cPickle as pickle
   USING_CPICKLE = True
-except:
+except Exception:
   import pickle
   USING_CPICKLE = False
 
@@ -57,7 +57,7 @@ def run_twistd_plugin(filename):
     try:
         from twisted.internet import epollreactor
         twistd_options.append("--reactor=epoll")
-    except:
+    except Exception:
         pass
 
     if options.debug or options.nodaemon:

--- a/lib/carbon/writer.py
+++ b/lib/carbon/writer.py
@@ -130,7 +130,7 @@ def writeCachedDataPoints():
         whisper.update_many(dbFilePath, datapoints)
         t2 = time.time()
         updateTime = t2 - t1
-      except:
+      except Exception:
         log.msg("Error writing to %s" % (dbFilePath))
         log.err()
         instrumentation.increment('errors')
@@ -162,7 +162,7 @@ def writeForever():
   while reactor.running:
     try:
       writeCachedDataPoints()
-    except:
+    except Exception:
       log.err()
 
     time.sleep(1)  # The writer thread only sleeps when the cache is empty or an error occurs
@@ -172,7 +172,7 @@ def reloadStorageSchemas():
   global schemas
   try:
     schemas = loadStorageSchemas()
-  except:
+  except Exception:
     log.msg("Failed to reload storage schemas")
     log.err()
 
@@ -181,7 +181,7 @@ def reloadAggregationSchemas():
   global agg_schemas
   try:
     agg_schemas = loadAggregationSchemas()
-  except:
+  except Exception:
     log.msg("Failed to reload aggregation schemas")
     log.err()
 


### PR DESCRIPTION
Bare except blocks catch SystemExit and were making a significant number of our attempts to stop carbon daemons fail.
