### PR TITLE
The log message is not in the good condition. 'metric' is the original m...

### DIFF
--- a/lib/carbon/aggregator/receiver.py
+++ b/lib/carbon/aggregator/receiver.py
@@ -32,5 +32,7 @@ def process(metric, datapoint):
     metric = rule.apply(metric)
 
   if metric not in aggregate_metrics:
-    log.msg("Couldn't match metric %s with any aggregation rule. Passing on un-aggregated." % metric)
     events.metricGenerated(metric, datapoint)
+
+  if len(aggregate_metrics) == 0:
+    log.msg("Couldn't match metric %s with any aggregation rule. Passing on un-aggregated." % metric)


### PR DESCRIPTION
...etric to be aggregated. It will never match an aggregated metric. If the aggregate_metrics array is empty, this is where it means the metric didn't match any rule
