### PR TITLE
0.9.x nodaemon backport (rebase of #144 to 0.9.x branch)

### DIFF
--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -408,6 +408,9 @@ def get_default_parser(usage="%prog [options] <start|stop|status>"):
         "--debug", action="store_true",
         help="Run in the foreground, log to stdout")
     parser.add_option(
+        "--nodaemon", action="store_true",
+        help="Run in the foreground")
+    parser.add_option(
         "--profile",
         help="Record performance profile data to the given file")
     parser.add_option(

--- a/lib/carbon/util.py
+++ b/lib/carbon/util.py
@@ -62,7 +62,7 @@ def run_twistd_plugin(filename):
     except:
         pass
 
-    if options.debug:
+    if options.debug or options.nodaemon:
         twistd_options.extend(["--nodaemon"])
     if options.profile:
         twistd_options.append("--profile")
@@ -79,7 +79,7 @@ def run_twistd_plugin(filename):
 
     for option_name, option_value in vars(options).items():
         if (option_value is not None and
-            option_name not in ("debug", "profile", "pidfile", "umask")):
+            option_name not in ("debug", "profile", "pidfile", "umask", "nodaemon")):
             twistd_options.extend(["--%s" % option_name.replace("_", "-"),
                                    option_value])
 


### PR DESCRIPTION
I'm not sure if Twisted version pinning required, removed it from commit.
@jib @obfuscurity ?
