### PR TITLE
change install-lib back to $(prefex)/lib from $(prefix)/webapp .. pretty...

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ else:
     except ConfigParser.DuplicateSectionError:
         pass
     cf.set('install', 'prefix', '/opt/graphite')
-    cf.set('install', 'install-lib', '%(prefix)s/webapp')
+    cf.set('install', 'install-lib', '%(prefix)s/lib')
 
 with open('setup.cfg', 'wb') as f:
     cf.write(f)


### PR DESCRIPTION
... sure carbon libs do not go in the webapp folder

fixes: https://github.com/graphite-project/carbon/issues/281
