### PR TITLE
add a copy of the description as long_description. RPM uses this as the ...

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ try:
       author_email='chrismd@gmail.com',
       license='Apache Software License 2.0',
       description='Backend data caching and persistence daemon for Graphite',
+      long_description='Backend data caching and persistence daemon for Graphite',
       packages=['carbon', 'carbon.aggregator', 'twisted.plugins'],
       package_dir={'' : 'lib'},
       scripts=glob('bin/*'),


### PR DESCRIPTION
...%description field and if it is not found it uses UNKNOWN which is sort of ugly

fixes: https://github.com/graphite-project/carbon/issues/283
