### PR TITLE
log.msg refer to old configuration option, which raise ConfigError...

### DIFF
--- a/lib/carbon/writer.py
+++ b/lib/carbon/writer.py
@@ -179,7 +179,7 @@ def shutdown_modify_update_speed():
   global write_ratelimit
   if settings.MAX_WRITES_PER_SECOND_SHUTDOWN != settings.MAX_WRITES_PER_SECOND:
     write_ratelimit = RateLimit(settings.MAX_WRITES_PER_SECOND_SHUTDOWN, 1)
-    log.msg("Carbon shutting down.  Changed the update rate to: " + str(settings.MAX_UPDATES_PER_SECOND_ON_SHUTDOWN))
+    log.msg("Carbon shutting down.  Changed the update rate to: " + str(settings.MAX_WRITES_PER_SECOND_SHUTDOWN))
 
 
 class WriterService(Service):


### PR DESCRIPTION
I found that when you send stop command to writer process raise ConfigError exception, and process never stopped. 
Old metric name were in log message.
