### PR TITLE
Use log.err instead of log.msg

### DIFF
--- a/lib/carbon/writer.py
+++ b/lib/carbon/writer.py
@@ -126,7 +126,7 @@ def writeCachedDataPoints():
           whisper.create(dbFilePath, archiveConfig, xFilesFactor, aggregationMethod, settings.WHISPER_SPARSE_CREATE, settings.WHISPER_FALLOCATE_CREATE)
           instrumentation.increment('creates')
         except Exception, e:
-          log.msg("Error creating %s: %s" % (dbFilePath,e))
+          log.err("Error creating %s: %s" % (dbFilePath,e))
           continue
 
       try:


### PR DESCRIPTION
As suggested by @drawks, refs #154.
