### PR TITLE
fix: carbon-relay unable to start with relay_method=aggregated-consistent-hashing

### DIFF
--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -357,13 +357,13 @@ class CarbonCacheOptions(usage.Options):
                         print "Could not remove pidfile %s" % pidfile
             # Try to create the PID directory
             else:
-                if not os.path.exists(settings["PID_DIR"]): 
+                if not os.path.exists(settings["PID_DIR"]):
                     try:
                         os.makedirs(settings["PID_DIR"])
                     except OSError as exc: # Python >2.5
                         if exc.errno == errno.EEXIST and os.path.isdir(settings["PID_DIR"]):
                            pass
-                        else: 
+                        else:
                            raise
 
 
@@ -410,7 +410,7 @@ class CarbonRelayOptions(CarbonCacheOptions):
 
         if self["aggregation-rules"] is None:
             self["rules"] = join(settings["CONF_DIR"], settings['AGGREGATION_RULES'])
-        settings["aggregation-rules"] = self["aggregation-rules"]
+        settings["aggregation-rules"] = self["rules"]
 
         if settings["RELAY_METHOD"] not in ("rules", "consistent-hashing", "aggregated-consistent-hashing"):
             print ("In carbon.conf, RELAY_METHOD must be either 'rules' or "


### PR DESCRIPTION
without this fix, carbon-relay will fail as follows:
Traceback (most recent call last):
  File "/opt/graphite/bin/carbon-relay.py", line 32, in <module>
    run_twistd_plugin(**file**)
  File "/opt/graphite/lib/carbon/util.py", line 91, in run_twistd_plugin
    runApp(config)
  File "/usr/lib/python2.7/dist-packages/twisted/scripts/twistd.py", line 23, in runApp
    _SomeApplicationRunner(config).run()
  File "/usr/lib/python2.7/dist-packages/twisted/application/app.py", line 376, in run
    self.application = self.createOrGetApplication()
  File "/usr/lib/python2.7/dist-packages/twisted/application/app.py", line 436, in createOrGetApplication
    ser = plg.makeService(self.config.subOptions)
  File "/opt/graphite/lib/twisted/plugins/carbon_relay_plugin.py", line 21, in makeService
    return service.createRelayService(options)
  File "/opt/graphite/lib/carbon/service.py", line 187, in createRelayService
    RuleManager.read_from(settings["aggregation-rules"])
  File "/opt/graphite/lib/carbon/aggregator/rules.py", line 21, in read_from
    self.read_rules()
  File "/opt/graphite/lib/carbon/aggregator/rules.py", line 25, in read_rules
    if not exists(self.rules_file):
  File "/usr/lib/python2.7/genericpath.py", line 18, in exists
    os.stat(path)
TypeError: coercing to Unicode: need string or buffer, NoneType found
