### PR TITLE
Add hup signal handler (refactors #198)

### DIFF
--- a/lib/carbon/client.py
+++ b/lib/carbon/client.py
@@ -9,6 +9,11 @@ from carbon import log, state, instrumentation
 from collections import deque
 from time import time
 
+try:
+    import signal
+except ImportError:
+    log.debug("Couldn't import signal module")
+
 
 SEND_QUEUE_LOW_WATERMARK = settings.MAX_QUEUE_SIZE * settings.QUEUE_LOW_WATERMARK_PCT
 
@@ -318,6 +323,9 @@ class CarbonClientManager(Service):
     self.client_factories = {} # { destination : CarbonClientFactory() }
 
   def startService(self):
+    if 'signal' in globals().keys():
+      log.debug("Installing SIG_IGN for SIGHUP")
+      signal.signal(signal.SIGHUP, signal.SIG_IGN)
     Service.startService(self)
     for factory in self.client_factories.values():
       if not factory.started:

--- a/lib/carbon/writer.py
+++ b/lib/carbon/writer.py
@@ -29,6 +29,11 @@ from twisted.internet import reactor
 from twisted.internet.task import LoopingCall
 from twisted.application.service import Service
 
+try:
+    import signal
+except ImportError:
+    log.debug("Couldn't import signal module")
+
 
 lastCreateInterval = 0
 createCount = 0
@@ -199,6 +204,9 @@ class WriterService(Service):
         self.aggregation_reload_task = LoopingCall(reloadAggregationSchemas)
 
     def startService(self):
+        if 'signal' in globals().keys():
+          log.debug("Installing SIG_IGN for SIGHUP")
+          signal.signal(signal.SIGHUP, signal.SIG_IGN)
         self.storage_reload_task.start(60, False)
         self.aggregation_reload_task.start(60, False)
         reactor.addSystemEventTrigger('before', 'shutdown', shutdownModifyUpdateSpeed)


### PR DESCRIPTION
@pcn - This refactors your fix in #198 to move the handler closer to twisted so we catch and ignore HUP regardless of how carbon is launched.

Closes https://github.com/graphite-project/carbon/pull/198
Fixes https://github.com/graphite-project/carbon/pull/197
