### PR TITLE
twistd syslog support

### DIFF
--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -426,6 +426,9 @@ def get_default_parser(usage="%prog [options] <start|stop|status>"):
         "--debug", action="store_true",
         help="Run in the foreground, log to stdout")
     parser.add_option(
+        "--syslog", action="store_true",
+        help="Write logs to syslog")
+    parser.add_option(
         "--nodaemon", action="store_true",
         help="Run in the foreground")
     parser.add_option(

--- a/lib/carbon/util.py
+++ b/lib/carbon/util.py
@@ -69,6 +69,8 @@ def run_twistd_plugin(filename):
         twistd_options.extend(["--pidfile", options.pidfile])
     if options.umask:
         twistd_options.extend(["--umask", options.umask])
+    if options.syslog:
+        twistd_options.append("--syslog")
 
     # Now for the plugin-specific options.
     twistd_options.append(program)
@@ -78,7 +80,7 @@ def run_twistd_plugin(filename):
 
     for option_name, option_value in vars(options).items():
         if (option_value is not None and
-            option_name not in ("debug", "profile", "pidfile", "umask", "nodaemon")):
+            option_name not in ("debug", "profile", "pidfile", "umask", "nodaemon", "syslog")):
             twistd_options.extend(["--%s" % option_name.replace("_", "-"),
                                    option_value])
 


### PR DESCRIPTION
Unable to use twistd option syslog when starting carbon cache from /usr/bin/carbon-cache.