### PR TITLE
add option to turn off logging of unmatched aggergation metrics

### DIFF
--- a/conf/carbon.conf.example
+++ b/conf/carbon.conf.example
@@ -379,3 +379,7 @@ MAX_AGGREGATION_INTERVALS = 5
 # In order to turn off logging of successful connections for the line
 # receiver, set this to False
 # LOG_LISTENER_CONN_SUCCESS = True
+
+# In order to turn off logging of metrics with no corresponding
+# aggregation rules receiver, set this to False
+# LOG_AGGREGATOR_MISSES = False

--- a/lib/carbon/aggregator/receiver.py
+++ b/lib/carbon/aggregator/receiver.py
@@ -2,6 +2,7 @@ from carbon.instrumentation import increment
 from carbon.aggregator.rules import RuleManager
 from carbon.aggregator.buffers import BufferManager
 from carbon.rewrite import RewriteRuleManager
+from carbon.conf import settings
 from carbon import events, log
 
 
@@ -34,5 +35,5 @@ def process(metric, datapoint):
   if metric not in aggregate_metrics:
     events.metricGenerated(metric, datapoint)
 
-  if len(aggregate_metrics) == 0:
+  if settings.LOG_AGGREGATOR_MISSES and len(aggregate_metrics) == 0:
     log.msg("Couldn't match metric %s with any aggregation rule. Passing on un-aggregated." % metric)

--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -75,6 +75,7 @@ defaults = dict(
   MIN_RESET_INTERVAL=121,
   USE_RATIO_RESET=False,
   LOG_LISTENER_CONN_SUCCESS=True,
+  LOG_AGGREGATOR_MISSES=True,
   AGGREGATION_RULES='aggregation-rules.conf',
   REWRITE_RULES='rewrite-rules.conf',
   RELAY_RULES='relay-rules.conf',


### PR DESCRIPTION
Logging aggregator misses is not always necessary. This adds an option to turn off unwanted log messages generated from aggregator misses.
