### PR TITLE
Allow manhole usage without ssh public-key

### DIFF
--- a/conf/carbon.conf.example
+++ b/conf/carbon.conf.example
@@ -194,6 +194,7 @@ WHISPER_AUTOFLUSH = False
 # MANHOLE_INTERFACE = 127.0.0.1
 # MANHOLE_PORT = 7222
 # MANHOLE_USER = admin
+# MANHOLE_PUBLIC_KEY = None  # if you want an empty password
 # MANHOLE_PUBLIC_KEY = ssh-rsa AAAAB3NzaC1yc2EAAAABiwAaAIEAoxN0sv/e4eZCPpi3N3KYvyzRaBaMeS2RsOQ/cDuKv11dlNzVeiyc3RFmCv5Rjwn/lQ79y0zyHxw67qLyhQ/kDzINc4cY41ivuQXm2tPmgvexdrBv5nsfEpjs3gLZfJnyvlcVyWK/lId8WUvEWSWHTzsbtmXAF2raJMdgLTbQ8wE=
 
 # Patterns for all of the metrics this machine will store. Read more at

--- a/lib/carbon/manhole.py
+++ b/lib/carbon/manhole.py
@@ -25,13 +25,14 @@ def createManholeListener():
   sshRealm = TerminalRealm()
   sshRealm.chainedProtocolFactory.protocolFactory = lambda _: Manhole(namespace)
 
-  # You can uncomment this if you're lazy and want insecure authentication instead
-  # of setting up keys.
-  #credChecker = checkers.InMemoryUsernamePasswordDatabaseDontUse(carbon='')
-  userKeys = {
-    settings.MANHOLE_USER : settings.MANHOLE_PUBLIC_KEY,
-  }
-  credChecker = PublicKeyChecker(userKeys)
+  if settings.MANHOLE_PUBLIC_KEY == 'None':
+    credChecker = checkers.InMemoryUsernamePasswordDatabaseDontUse()
+    credChecker.addUser(settings.MANHOLE_USER, '')
+  else:
+    userKeys = {
+        settings.MANHOLE_USER : settings.MANHOLE_PUBLIC_KEY,
+    }
+    credChecker = PublicKeyChecker(userKeys)
 
   sshPortal = portal.Portal(sshRealm)
   sshPortal.registerChecker(credChecker)


### PR DESCRIPTION
To simplify enrollment and debugging in a highly distributed environment, we preferred to use the manhole without key but only bound to localhost. This implements the capabilities to configure MANHOLE_PUBLIC_KEY = None.