### PR TITLE
Simplify README and add diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,79 +2,22 @@
 
 [![Build Status](https://secure.travis-ci.org/graphite-project/carbon.png?branch=master)](http://travis-ci.org/graphite-project/carbon)
 
-Carbon is one of the components of [Graphite][], and is responsible for
-receiving metrics over the network and writing them down to disk using a
-storage backend. Currently [Whisper][] is our stable, supported backend and
-[Ceres][] is the work-in-progress future replacement for Whisper.
-
-[Graphite]: https://github.com/graphite-project
-[Graphite Web]: https://github.com/graphite-project/graphite-web
-[Whisper]: https://github.com/graphite-project/whisper
-[Ceres]: https://github.com/graphite-project/ceres
-
 ## Overview
 
-Client applications can connect to the running carbon-cache.py daemon on port
-2003 (default) and send it lines of text of the following format:
+Carbon is one of three components within the Graphite project:
 
-    my.metric.name value unix_timestamp
+1. [Graphite-Web](https://github.com/graphite-project/graphite-web), a Django-based web application that renders graphs and dashboards
+2. The Carbon metric processing daemons
+3. The [Whisper](https://github.com/graphite-project/whisper) time-series database library
 
-For example:
+![Graphite Components](https://github.com/graphite-project/graphite-web/raw/master/webapp/content/img/overview.png "Graphite Components")
 
-    performance.servers.www01.cpuUsage 42.5 1208815315
+Carbon is responsible for receiving metrics over the network, caching them in memory for "hot queries" from the Graphite-Web application, and persisting them to disk using the Whisper time-series library.
 
-- The metric name is like a filesystem path that uses a dot as a separator instead of
-a forward-slash.
+## Installation, Configuration and Usage
 
-- The value is some scalar integer or floating point value 
+Please refer to the instructions at [readthedocs](http://graphite.readthedocs.org/).
 
-- The unix_timestamp is unix epoch time, as an integer.
+## License
 
-Each line like this corresponds to one data point for one metric.
-
-Alternatively, they can send pickle-formatted messages to port 2004 (default)
-which is considered faster than the line-based format.
-
-Once you've got some clients sending data to carbon-cache, you can view
-graphs of that data through the frontend [Graphite Web][] application.
-
-## Running carbon-cache.py
-
-First you must tell carbon-cache what user it should run as.  This must be a
-user with write privileges to `$GRAPHITE_ROOT/storage/whisper`. Specify the
-user account in `$GRAPHITE_ROOT/conf/carbon.conf`. This user must also have
-write privileges to `$GRAPHITE_ROOT/storage/log/carbon-cache`
-
-Alternatively, you can run `carbon-cache`/`carbon-relay`/`carbon-aggregator` as
-[Twistd plugins][], for example:
-
-    Usage: twistd [options] carbon-cache [options]
-    Options:
-          --debug       Run in debug mode.
-      -c, --config=     Use the given config file.
-          --instance=   Manage a specific carbon instance. [default: a]
-          --logdir=     Write logs to the given directory.
-          --whitelist=  List of metric patterns to allow.
-          --blacklist=  List of metric patterns to disallow.
-          --version     Display Twisted version and exit.
-          --help        Display this help and exit.
-
-Common options to `twistd(1)`, like `--pidfile`, `--logfile`, `--uid`, `--gid`,
-`--syslog` and `--prefix` are fully supported and have precedence over
-`carbon-*`'s own options. Please refer to `twistd --help` for the full list of
-supported `twistd` options.
-
-[Twistd plugins]: http://twistedmatrix.com/documents/current/core/howto/plugin.html
-
-## Writing a client
-
-First you obviously need to decide what data it is you want to graph with
-graphite. The script [examples/example-client.py] demonstrates a simple client
-that sends `loadavg` data for your local machine to carbon on a minutely basis.
-
-The default storage schema stores data in one-minute intervals for 2 hours.
-This is probably not what you want so you should create a custom storage schema
-according to the docs on the [Graphite wiki][].
-
-[Graphite wiki]: http://graphite.wikidot.com
-[examples/example-client.py]: https://github.com/graphite-project/carbon/blob/master/examples/example-client.py
+Carbon is licensed under version 2.0 of the Apache License. See the [LICENSE](https://github.com/graphite-project/carbon/blob/master/LICENSE) file for details.


### PR DESCRIPTION
Backport #353 to 0.9.x
N.B. - maybe it's need to be pointed to https://graphite.readthedocs.org/en/0.9.13/ instead of https://graphite.readthedocs.org/en/latest/ but 0.9.13 is not exist yet and pointing to 0.9.13-pre1 is quite pointless IMO...