### PR TITLE
Close connection after n seconds if no data is received

### DIFF
--- a/conf/carbon.conf.example
+++ b/conf/carbon.conf.example
@@ -30,6 +30,9 @@
 #
 #LOCAL_DATA_DIR = /opt/graphite/storage/whisper/
 
+#Twisted TCP server timeout if no read after n seconds
+#TIMEOUT = 60
+
 # Enable daily log rotation. If disabled, a new file will be opened whenever the log file path no
 # longer exists (i.e. it is removed or renamed)
 ENABLE_LOGROTATION = True

--- a/conf/carbon.conf.example
+++ b/conf/carbon.conf.example
@@ -31,7 +31,7 @@
 #LOCAL_DATA_DIR = /opt/graphite/storage/whisper/
 
 #Twisted TCP server timeout if no read after n seconds
-#TIMEOUT = 60
+#TIMEOUT = None
 
 # Enable daily log rotation. If disabled, a new file will be opened whenever the log file path no
 # longer exists (i.e. it is removed or renamed)

--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -81,7 +81,7 @@ defaults = dict(
   REWRITE_RULES='rewrite-rules.conf',
   RELAY_RULES='relay-rules.conf',
   ENABLE_LOGROTATE=True,
-  TIMEOUT=60,
+  TIMEOUT=None,
 )
 
 

--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -81,6 +81,7 @@ defaults = dict(
   REWRITE_RULES='rewrite-rules.conf',
   RELAY_RULES='relay-rules.conf',
   ENABLE_LOGROTATE=True,
+  TIMEOUT=60,
 )
 
 


### PR DESCRIPTION
It allows carbon to close connection after n seconds if no data is received from it. The client will then have to reconnect in order to continue sending data. It's fixed using helper in Twisted called: "TimeoutMixin".