### PR TITLE
Hot data storage

### DIFF
--- a/conf/hot-storage-aggregation.conf.example
+++ b/conf/hot-storage-aggregation.conf.example
@@ -1,0 +1,32 @@
+# Aggregation methods for whisper files. Entries are scanned in order,
+# and first match wins. This file is scanned for changes every 60 seconds
+#
+#  [name]
+#  pattern = <regex>
+#  xFilesFactor = <float between 0 and 1>
+#  aggregationMethod = <average|sum|last|max|min>
+#
+#  name: Arbitrary unique name for the rule
+#  pattern: Regex pattern to match against the metric name
+#  xFilesFactor: Ratio of valid data points required for aggregation to the next retention to occur
+#  aggregationMethod: function to apply to data points for aggregation
+#
+[min]
+pattern = \.min$
+xFilesFactor = 0.1
+aggregationMethod = min
+
+[max]
+pattern = \.max$
+xFilesFactor = 0.1
+aggregationMethod = max
+
+[sum]
+pattern = \.count$
+xFilesFactor = 0
+aggregationMethod = sum
+
+[default_average]
+pattern = .*
+xFilesFactor = 0.5
+aggregationMethod = average

--- a/conf/hot-storage-schemas.conf.example
+++ b/conf/hot-storage-schemas.conf.example
@@ -1,0 +1,26 @@
+# Schema definitions for Whisper files. Entries are scanned in order,
+# and first match wins. This file is scanned for changes every 60 seconds.
+#
+# Definition Syntax:
+#
+#    [name]
+#    pattern = regex
+#    retentions = timePerPoint:timeToStore, timePerPoint:timeToStore, ...
+#
+# Remember: To support accurate aggregation from higher to lower resolution
+#           archives, the precision of a longer retention archive must be
+#           cleanly divisible by precision of next lower retention archive.
+#
+#           Valid:    60s:7d,300s:30d (300/60 = 5)
+#           Invalid:  180s:7d,300s:30d (300/180 = 3.333)
+#
+
+# Carbon's internal metrics. This entry should match what is specified in
+# CARBON_METRIC_PREFIX and CARBON_METRIC_INTERVAL settings
+[carbon]
+pattern = ^carbon\.
+retentions = 60:90d
+
+[default_1min_for_1day]
+pattern = .*
+retentions = 60s:1d

--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -17,7 +17,7 @@ import sys
 import pwd
 import errno
 
-from os.path import join, dirname, normpath, exists, isdir
+from os.path import join, dirname, normpath, exists, isdir, isfile
 from optparse import OptionParser
 from ConfigParser import ConfigParser
 
@@ -81,6 +81,7 @@ defaults = dict(
   REWRITE_RULES='rewrite-rules.conf',
   RELAY_RULES='relay-rules.conf',
   ENABLE_LOGROTATE=True,
+  USE_HOT_STORAGE=False,
 )
 
 
@@ -212,6 +213,7 @@ class CarbonCacheOptions(usage.Options):
         # Normalize and expand paths
         settings["STORAGE_DIR"] = os.path.normpath(os.path.expanduser(settings["STORAGE_DIR"]))
         settings["LOCAL_DATA_DIR"] = os.path.normpath(os.path.expanduser(settings["LOCAL_DATA_DIR"]))
+        settings["HOT_DATA_DIR"] = os.path.normpath(os.path.expanduser(settings["HOT_DATA_DIR"]))
         settings["WHITELISTS_DIR"] = os.path.normpath(os.path.expanduser(settings["WHITELISTS_DIR"]))
         settings["PID_DIR"] = os.path.normpath(os.path.expanduser(settings["PID_DIR"]))
         settings["LOG_DIR"] = os.path.normpath(os.path.expanduser(settings["LOG_DIR"]))
@@ -248,6 +250,10 @@ class CarbonCacheOptions(usage.Options):
                 whisper.LOCK = True
             else:
                 log.err("WHISPER_LOCK_WRITES is enabled but import of fcntl module failed.")
+
+        hot_storage_dir = settings["HOT_DATA_DIR"]
+        hot_storage_schemas = join(settings["CONF_DIR"], "hot-storage-schemas.conf")
+        settings.USE_HOT_STORAGE = isdir(hot_storage_dir) and isfile(hot_storage_schemas)
 
         if not "action" in self:
             self["action"] = "start"
@@ -546,6 +552,8 @@ def read_config(program, options, **kwargs):
         "LOG_DIR", join(settings["STORAGE_DIR"], "log", program))
     settings.setdefault(
         "LOCAL_DATA_DIR", join(settings["STORAGE_DIR"], "whisper"))
+    settings.setdefault(
+        "HOT_DATA_DIR", join(settings["STORAGE_DIR"], "hot_whisper"))
     settings.setdefault(
         "WHITELISTS_DIR", join(settings["STORAGE_DIR"], "lists"))
 

--- a/lib/carbon/instrumentation.py
+++ b/lib/carbon/instrumentation.py
@@ -109,8 +109,8 @@ def recordMetrics():
     record('errors', errors)
     record('cache.queries', cacheQueries)
     record('cache.bulk_queries', cacheBulkQueries)
-    record('cache.queues', len(cache.MetricCache))
-    record('cache.size', cache.MetricCache.size)
+    record('cache.queues', sum([ len(c) for c in cache.metric_caches]))
+    record('cache.size', sum([ c.size for c in cache.metric_caches]))
     record('cache.overflow', cacheOverflow)
 
   # aggregator metrics
@@ -158,7 +158,8 @@ def cache_record(metric, value):
     else:
       fullMetric = '%s.agents.%s-%s.%s' % (prefix, HOSTNAME, settings.instance, metric)
     datapoint = (time.time(), value)
-    cache.MetricCache.store(fullMetric, datapoint)
+    for c in cache.metric_caches:
+      c.store(fullMetric, datapoint)
 
 def relay_record(metric, value):
     prefix = settings.CARBON_METRIC_PREFIX

--- a/lib/carbon/management.py
+++ b/lib/carbon/management.py
@@ -1,7 +1,7 @@
 import traceback
 import whisper
 from carbon import log
-from carbon.storage import getFilesystemPath
+from carbon.storage import storage
 
 
 
@@ -9,7 +9,7 @@ def getMetadata(metric, key):
   if key != 'aggregationMethod':
     return dict(error="Unsupported metadata key \"%s\"" % key)
 
-  wsp_path = getFilesystemPath(metric)
+  wsp_path = storage.getFilesystemPath(metric)
   try:
     value = whisper.info(wsp_path)['aggregationMethod']
     return dict(value=value)
@@ -22,7 +22,7 @@ def setMetadata(metric, key, value):
   if key != 'aggregationMethod':
     return dict(error="Unsupported metadata key \"%s\"" % key)
 
-  wsp_path = getFilesystemPath(metric)
+  wsp_path = storage.getFilesystemPath(metric)
   try:
     old_value = whisper.setAggregationMethod(wsp_path, value)
     return dict(old_value=old_value, new_value=value)

--- a/lib/carbon/tests/test_cache.py
+++ b/lib/carbon/tests/test_cache.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from mock import Mock, PropertyMock, patch
-from carbon.cache import _MetricCache, DrainStrategy, MaxStrategy, RandomStrategy, SortedStrategy
+from carbon.cache import MetricCache, DrainStrategy, MaxStrategy, RandomStrategy, SortedStrategy
 
 
 class MetricCacheTest(TestCase):
@@ -12,13 +12,13 @@ class MetricCacheTest(TestCase):
     self._settings_patch = patch.dict('carbon.conf.settings', settings)
     self._settings_patch.start()
     self.strategy_mock = Mock(spec=DrainStrategy)
-    self.metric_cache = _MetricCache(self.strategy_mock)
+    self.metric_cache = MetricCache(self.strategy_mock)
 
   def tearDown(self):
     self._settings_patch.stop()
 
   def test_cache_is_a_dict(self):
-    self.assertTrue(issubclass(_MetricCache, dict))
+    self.assertTrue(issubclass(MetricCache, dict))
 
   def test_initial_size(self):
     self.assertEqual(0, self.metric_cache.size)
@@ -44,15 +44,15 @@ class MetricCacheTest(TestCase):
 
   def test_store_checks_fullness(self):
     is_full_mock = PropertyMock()
-    with patch.object(_MetricCache, 'is_full', is_full_mock):
+    with patch.object(MetricCache, 'is_full', is_full_mock):
       with patch('carbon.cache.events'):
-        metric_cache = _MetricCache()
+        metric_cache = MetricCache()
         metric_cache.store('foo', (123456, 1.0))
         is_full_mock.assert_called_once()
 
   def test_store_on_full_triggers_events(self):
     is_full_mock = PropertyMock(return_value=True)
-    with patch.object(_MetricCache, 'is_full', is_full_mock):
+    with patch.object(MetricCache, 'is_full', is_full_mock):
       with patch('carbon.cache.events') as events_mock:
         self.metric_cache.store('foo', (123456, 1.0))
         events_mock.return_value.cacheFull.assert_called_once()
@@ -118,7 +118,7 @@ class MetricCacheTest(TestCase):
     self.assertEqual('foo', self.metric_cache.drain_metric()[0])
 
   def test_drain_metric_works_without_strategy(self):
-    metric_cache = _MetricCache()  # No strategy
+    metric_cache = MetricCache()  # No strategy
 
     metric_cache.store('foo', (123456, 1.0))
     self.assertEqual('foo', metric_cache.drain_metric()[0])
@@ -157,7 +157,7 @@ class MetricCacheTest(TestCase):
 
 class DrainStrategyTest(TestCase):
   def setUp(self):
-    self.metric_cache = _MetricCache()
+    self.metric_cache = MetricCache()
 
   def test_max_strategy(self):
     self.metric_cache.store('foo', (123456, 1.0))
@@ -220,7 +220,7 @@ class DrainStrategyTest(TestCase):
 
 class RandomStrategyTest(TestCase):
   def setUp(self):
-    self.metric_cache = _MetricCache()
+    self.metric_cache = MetricCache()
 
   def test_random_strategy(self):
     self.metric_cache.store('foo', (123456, 1.0))

--- a/lib/carbon/tests/test_hashing.py
+++ b/lib/carbon/tests/test_hashing.py
@@ -4,81 +4,99 @@ from carbon.hashing import ConsistentHashRing
 
 class HashIntegrityTest(unittest.TestCase):
 
-    def test_2_node_positional_itegrity(self):
-        """Make a cluster, verify we don't have positional collisions"""
-        ring = ConsistentHashRing([])
-        for n in range(2):
-            ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
-        self.assertEqual(
-                len([n[0] for n in ring.ring]),
-            len(set([n[0] for n in ring.ring])))
+  def test_2_node_positional_itegrity(self):
+    """Make a cluster, verify we don't have positional collisions"""
+    ring = ConsistentHashRing([])
+    for n in range(2):
+      ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
+    self.assertEqual(
+      len([n[0] for n in ring.ring]),
+      len(set([n[0] for n in ring.ring])))
 
 
-    def test_3_node_positional_itegrity(self):
-        """Make a cluster, verify we don't have positional collisions"""
-        ring = ConsistentHashRing([])
-        for n in range(3):
-            ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
-        self.assertEqual(
-                len([n[0] for n in ring.ring]),
-            len(set([n[0] for n in ring.ring])))
+  def test_3_node_positional_itegrity(self):
+    """Make a cluster, verify we don't have positional collisions"""
+    ring = ConsistentHashRing([])
+    for n in range(3):
+      ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
+    self.assertEqual(
+      len([n[0] for n in ring.ring]),
+      len(set([n[0] for n in ring.ring])))
 
 
-    def test_4_node_positional_itegrity(self):
-        """Make a cluster, verify we don't have positional collisions"""
-        ring = ConsistentHashRing([])
-        for n in range(4):
-            ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
-        self.assertEqual(
-                len([n[0] for n in ring.ring]),
-            len(set([n[0] for n in ring.ring])))
+  def test_4_node_positional_itegrity(self):
+    """Make a cluster, verify we don't have positional collisions"""
+    ring = ConsistentHashRing([])
+    for n in range(4):
+      ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
+    self.assertEqual(
+      len([n[0] for n in ring.ring]),
+      len(set([n[0] for n in ring.ring])))
 
 
-    def test_5_node_positional_itegrity(self):
-        """Make a cluster, verify we don't have positional collisions"""
-        ring = ConsistentHashRing([])
-        for n in range(5):
-            ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
-        self.assertEqual(
-                len([n[0] for n in ring.ring]),
-            len(set([n[0] for n in ring.ring])))
+  def test_5_node_positional_itegrity(self):
+    """Make a cluster, verify we don't have positional collisions"""
+    ring = ConsistentHashRing([])
+    for n in range(5):
+      ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
+    self.assertEqual(
+      len([n[0] for n in ring.ring]),
+      len(set([n[0] for n in ring.ring])))
 
 
-    def test_6_node_positional_itegrity(self):
-        """Make a cluster, verify we don't have positional collisions"""
-        ring = ConsistentHashRing([])
-        for n in range(6):
-            ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
-        self.assertEqual(
-                len([n[0] for n in ring.ring]),
-            len(set([n[0] for n in ring.ring])))
+  def test_6_node_positional_itegrity(self):
+    """Make a cluster, verify we don't have positional collisions"""
+    ring = ConsistentHashRing([])
+    for n in range(6):
+      ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
+    self.assertEqual(
+      len([n[0] for n in ring.ring]),
+      len(set([n[0] for n in ring.ring])))
 
 
-    def test_7_node_positional_itegrity(self):
-        """Make a cluster, verify we don't have positional collisions"""
-        ring = ConsistentHashRing([])
-        for n in range(7):
-            ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
-        self.assertEqual(
-                len([n[0] for n in ring.ring]),
-            len(set([n[0] for n in ring.ring])))
+  def test_7_node_positional_itegrity(self):
+    """Make a cluster, verify we don't have positional collisions"""
+    ring = ConsistentHashRing([])
+    for n in range(7):
+      ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
+    self.assertEqual(
+      len([n[0] for n in ring.ring]),
+      len(set([n[0] for n in ring.ring])))
 
 
-    def test_8_node_positional_itegrity(self):
-        """Make a cluster, verify we don't have positional collisions"""
-        ring = ConsistentHashRing([])
-        for n in range(8):
-            ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
-        self.assertEqual(
-                len([n[0] for n in ring.ring]),
-            len(set([n[0] for n in ring.ring])))
+  def test_8_node_positional_itegrity(self):
+    """Make a cluster, verify we don't have positional collisions"""
+    ring = ConsistentHashRing([])
+    for n in range(8):
+      ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
+    self.assertEqual(
+      len([n[0] for n in ring.ring]),
+      len(set([n[0] for n in ring.ring])))
 
 
-    def test_9_node_positional_itegrity(self):
-        """Make a cluster, verify we don't have positional collisions"""
-        ring = ConsistentHashRing([])
-        for n in range(9):
-            ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
-        self.assertEqual(
-                len([n[0] for n in ring.ring]),
-            len(set([n[0] for n in ring.ring])))
+  def test_9_node_positional_itegrity(self):
+    """Make a cluster, verify we don't have positional collisions"""
+    ring = ConsistentHashRing([])
+    for n in range(9):
+      ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
+    self.assertEqual(
+      len([n[0] for n in ring.ring]),
+      len(set([n[0] for n in ring.ring])))
+
+  def test_insensetivity_to_nodes_order(self):
+    import random
+    ring1 = ConsistentHashRing([])
+    ring2 = ConsistentHashRing([])
+
+    nodes = [ ("192.168.10.%s" % str(10+n),"%s" % str(10+n)) for n in range(1, 11)]
+    random.shuffle(nodes)
+    for n in nodes:
+      ring1.add_node(n)
+
+    random.shuffle(nodes)
+    for n in nodes:
+      ring2.add_node(n)
+
+    for n in range(0, 10):
+      key = random.randint(0, 100)
+      self.assertEqual(ring1.get_node(key), ring2.get_node(key))

--- a/lib/carbon/writer.py
+++ b/lib/carbon/writer.py
@@ -18,15 +18,11 @@ from os.path import exists, dirname
 
 import whisper
 from carbon import state
-from carbon.cache import MetricCache
-from carbon.storage import getFilesystemPath, loadStorageSchemas,\
-    loadAggregationSchemas
 from carbon.conf import settings
 from carbon import log, events, instrumentation
 from carbon.util import TokenBucket
 
 from twisted.internet import reactor
-from twisted.internet.task import LoopingCall
 from twisted.application.service import Service
 
 try:
@@ -35,179 +31,161 @@ except ImportError:
     log.debug("Couldn't import signal module")
 
 
-SCHEMAS = loadStorageSchemas()
-AGGREGATION_SCHEMAS = loadAggregationSchemas()
 CACHE_SIZE_LOW_WATERMARK = settings.MAX_CACHE_SIZE * 0.95
 
 
-# Inititalize token buckets so that we can enforce rate limits on creates and
-# updates if the config wants them.
-CREATE_BUCKET = None
-UPDATE_BUCKET = None
-if settings.MAX_CREATES_PER_MINUTE != float('inf'):
-  capacity = settings.MAX_CREATES_PER_MINUTE
-  fill_rate = float(settings.MAX_CREATES_PER_MINUTE) / 60
-  CREATE_BUCKET = TokenBucket(capacity, fill_rate)
 
-if settings.MAX_UPDATES_PER_SECOND != float('inf'):
-  capacity = settings.MAX_UPDATES_PER_SECOND
-  fill_rate = settings.MAX_UPDATES_PER_SECOND
-  UPDATE_BUCKET = TokenBucket(capacity, fill_rate)
+class Writer:
+    def __init__(self, metric_cache, storage, max_creates_per_minute = settings.MAX_CREATES_PER_MINUTE,
+                 max_updates_per_second = settings.MAX_UPDATES_PER_SECOND):
+      self.metric_cache = metric_cache
+      self.storage = storage
 
+      # Inititalize token buckets so that we can enforce rate limits on creates and
+      # updates if the config wants them.
+      self.create_bucket = None
+      self.update_bucket = None
+      if max_creates_per_minute != float('inf'):
+        capacity = max_creates_per_minute
+        fill_rate = float(max_creates_per_minute) / 60
+        self.create_bucket = TokenBucket(capacity, fill_rate)
 
-def optimalWriteOrder():
-  """Generates metrics with the most cached values first and applies a soft
-  rate limit on new metrics"""
-  while MetricCache:
-    (metric, datapoints) = MetricCache.drain_metric()
-    if state.cacheTooFull and MetricCache.size < CACHE_SIZE_LOW_WATERMARK:
-      events.cacheSpaceAvailable()
+      if max_updates_per_second != float('inf'):
+        capacity = max_updates_per_second
+        fill_rate = max_updates_per_second
+        self.update_bucket = TokenBucket(capacity, fill_rate)
 
-    dbFilePath = getFilesystemPath(metric)
-    dbFileExists = exists(dbFilePath)
+    def optimalWriteOrder(self):
+      """Generates metrics with the most cached values first and applies a soft
+      rate limit on new metrics"""
+      while self.metric_cache:
+        (metric, datapoints) = self.metric_cache.drain_metric()
+        if state.cacheTooFull and self.metric_cache.size < CACHE_SIZE_LOW_WATERMARK:
+          events.cacheSpaceAvailable()
 
-    if not dbFileExists and CREATE_BUCKET:
-      # If our tokenbucket has enough tokens available to create a new metric
-      # file then yield the metric data to complete that operation. Otherwise
-      # we'll just drop the metric on the ground and move on to the next
-      # metric.
-      # XXX This behavior should probably be configurable to no tdrop metrics
-      # when rate limitng unless our cache is too big or some other legit
-      # reason.
-      if CREATE_BUCKET.drain(1):
+        dbFilePath = self.storage.getFilesystemPath(metric)
+        dbFileExists = exists(dbFilePath)
+
+        if not dbFileExists and self.create_bucket:
+          # If our tokenbucket has enough tokens available to create a new metric
+          # file then yield the metric data to complete that operation. Otherwise
+          # we'll just drop the metric on the ground and move on to the next
+          # metric.
+          # XXX This behavior should probably be configurable to no tdrop metrics
+          # when rate limitng unless our cache is too big or some other legit
+          # reason.
+          if self.create_bucket.drain(1):
+            yield (metric, datapoints, dbFilePath, dbFileExists)
+          continue
+
         yield (metric, datapoints, dbFilePath, dbFileExists)
-      continue
-
-    yield (metric, datapoints, dbFilePath, dbFileExists)
 
 
-def writeCachedDataPoints():
-  "Write datapoints until the MetricCache is completely empty"
+    def writeCachedDataPoints(self):
+      "Write datapoints until the self.metric_cache is completely empty"
 
-  while MetricCache:
-    dataWritten = False
+      while self.metric_cache:
+        dataWritten = False
 
-    for (metric, datapoints, dbFilePath, dbFileExists) in optimalWriteOrder():
-      dataWritten = True
+        for (metric, datapoints, dbFilePath, dbFileExists) in self.optimalWriteOrder():
+          dataWritten = True
 
-      if not dbFileExists:
-        archiveConfig = None
-        xFilesFactor, aggregationMethod = None, None
+          if not dbFileExists:
+            archiveConfig = None
+            xFilesFactor, aggregationMethod = None, None
 
-        for schema in SCHEMAS:
-          if schema.matches(metric):
-            log.creates('new metric %s matched schema %s' % (metric, schema.name))
-            archiveConfig = [archive.getTuple() for archive in schema.archives]
-            break
+            for schema in self.storage.storage_schemas:
+              if schema.matches(metric):
+                log.creates('new metric %s matched schema %s' % (metric, schema.name))
+                archiveConfig = [archive.getTuple() for archive in schema.archives]
+                break
 
-        for schema in AGGREGATION_SCHEMAS:
-          if schema.matches(metric):
-            log.creates('new metric %s matched aggregation schema %s' % (metric, schema.name))
-            xFilesFactor, aggregationMethod = schema.archives
-            break
+            for schema in self.storage.aggregation_schemas:
+              if schema.matches(metric):
+                log.creates('new metric %s matched aggregation schema %s' % (metric, schema.name))
+                xFilesFactor, aggregationMethod = schema.archives
+                break
 
-        if not archiveConfig:
-          raise Exception("No storage schema matched the metric '%s', check your storage-schemas.conf file." % metric)
+            if not archiveConfig:
+              raise Exception("No storage schema matched the metric '%s', check your storage-schemas.conf file." % metric)
 
-        dbDir = dirname(dbFilePath)
+            dbDir = dirname(dbFilePath)
+            try:
+                if not exists(dbDir):
+                    os.makedirs(dbDir)
+            except OSError, e:
+                log.err("%s" % e)
+            log.creates("creating database file %s (archive=%s xff=%s agg=%s)" %
+                        (dbFilePath, archiveConfig, xFilesFactor, aggregationMethod))
+            try:
+                whisper.create(
+                    dbFilePath,
+                    archiveConfig,
+                    xFilesFactor,
+                    aggregationMethod,
+                    settings.WHISPER_SPARSE_CREATE,
+                    settings.WHISPER_FALLOCATE_CREATE)
+                instrumentation.increment('creates')
+            except:
+                log.err("Error creating %s" % (dbFilePath))
+                continue
+          # If we've got a rate limit configured lets makes sure we enforce it
+          if self.update_bucket:
+            self.update_bucket.drain(1, blocking=True)
+          try:
+            t1 = time.time()
+            whisper.update_many(dbFilePath, datapoints)
+            updateTime = time.time() - t1
+          except Exception:
+            log.msg("Error writing to %s" % (dbFilePath))
+            log.err()
+            instrumentation.increment('errors')
+          else:
+            pointCount = len(datapoints)
+            instrumentation.increment('committedPoints', pointCount)
+            instrumentation.append('updateTimes', updateTime)
+            if settings.LOG_UPDATES:
+              log.updates("wrote %d datapoints for %s in %.5f seconds" % (pointCount, metric, updateTime))
+
+        # Avoid churning CPU when only new metrics are in the cache
+        if not dataWritten:
+          time.sleep(0.1)
+
+
+    def writeForever(self):
+      while reactor.running:
         try:
-            if not exists(dbDir):
-                os.makedirs(dbDir)
-        except OSError, e:
-            log.err("%s" % e)
-        log.creates("creating database file %s (archive=%s xff=%s agg=%s)" %
-                    (dbFilePath, archiveConfig, xFilesFactor, aggregationMethod))
+          self.writeCachedDataPoints()
+        except Exception:
+          log.err()
+        time.sleep(1)  # The writer thread only sleeps when the cache is empty or an error occurs
+
+    def shutdownModifyUpdateSpeed(self):
         try:
-            whisper.create(
-                dbFilePath,
-                archiveConfig,
-                xFilesFactor,
-                aggregationMethod,
-                settings.WHISPER_SPARSE_CREATE,
-                settings.WHISPER_FALLOCATE_CREATE)
-            instrumentation.increment('creates')
-        except:
-            log.err("Error creating %s" % (dbFilePath))
-            continue
-      # If we've got a rate limit configured lets makes sure we enforce it
-      if UPDATE_BUCKET:
-        UPDATE_BUCKET.drain(1, blocking=True)
-      try:
-        t1 = time.time()
-        whisper.update_many(dbFilePath, datapoints)
-        updateTime = time.time() - t1
-      except Exception:
-        log.msg("Error writing to %s" % (dbFilePath))
-        log.err()
-        instrumentation.increment('errors')
-      else:
-        pointCount = len(datapoints)
-        instrumentation.increment('committedPoints', pointCount)
-        instrumentation.append('updateTimes', updateTime)
-        if settings.LOG_UPDATES:
-          log.updates("wrote %d datapoints for %s in %.5f seconds" % (pointCount, metric, updateTime))
-
-    # Avoid churning CPU when only new metrics are in the cache
-    if not dataWritten:
-      time.sleep(0.1)
-
-
-def writeForever():
-  while reactor.running:
-    try:
-      writeCachedDataPoints()
-    except Exception:
-      log.err()
-    time.sleep(1)  # The writer thread only sleeps when the cache is empty or an error occurs
-
-
-def reloadStorageSchemas():
-  global SCHEMAS
-  try:
-    SCHEMAS = loadStorageSchemas()
-  except Exception:
-    log.msg("Failed to reload storage SCHEMAS")
-    log.err()
-
-
-def reloadAggregationSchemas():
-  global AGGREGATION_SCHEMAS
-  try:
-    AGGREGATION_SCHEMAS = loadAggregationSchemas()
-  except Exception:
-    log.msg("Failed to reload aggregation SCHEMAS")
-    log.err()
-
-
-def shutdownModifyUpdateSpeed():
-    try:
-        shut = settings.MAX_UPDATES_PER_SECOND_ON_SHUTDOWN
-        if UPDATE_BUCKET:
-          UPDATE_BUCKET.setCapacityAndFillRate(shut,shut)
-        if CREATE_BUCKET:
-          CREATE_BUCKET.setCapacityAndFillRate(shut,shut)
-        log.msg("Carbon shutting down.  Changed the update rate to: " + str(settings.MAX_UPDATES_PER_SECOND_ON_SHUTDOWN))
-    except KeyError:
-        log.msg("Carbon shutting down.  Update rate not changed")
+            shut = settings.MAX_UPDATES_PER_SECOND_ON_SHUTDOWN
+            if self.update_bucket:
+              self.update_bucket.setCapacityAndFillRate(shut,shut)
+            if self.create_bucket:
+              self.create_bucket.setCapacityAndFillRate(shut,shut)
+            log.msg("Carbon shutting down.  Changed the update rate to: " + str(settings.MAX_UPDATES_PER_SECOND_ON_SHUTDOWN))
+        except KeyError:
+            log.msg("Carbon shutting down.  Update rate not changed")
 
 
 class WriterService(Service):
 
-    def __init__(self):
-        self.storage_reload_task = LoopingCall(reloadStorageSchemas)
-        self.aggregation_reload_task = LoopingCall(reloadAggregationSchemas)
+    def __init__(self, writer):
+        self.writer = writer
 
     def startService(self):
         if 'signal' in globals().keys():
           log.debug("Installing SIG_IGN for SIGHUP")
           signal.signal(signal.SIGHUP, signal.SIG_IGN)
-        self.storage_reload_task.start(60, False)
-        self.aggregation_reload_task.start(60, False)
-        reactor.addSystemEventTrigger('before', 'shutdown', shutdownModifyUpdateSpeed)
-        reactor.callInThread(writeForever)
+        self.writer.storage.startRefreshes()
+        reactor.addSystemEventTrigger('before', 'shutdown', self.writer.shutdownModifyUpdateSpeed)
+        reactor.callInThread(self.writer.writeForever)
         Service.startService(self)
 
     def stopService(self):
-        self.storage_reload_task.stop()
-        self.aggregation_reload_task.stop()
+        self.writer.storage.stopRefreshes()
         Service.stopService(self)

--- a/lib/twisted/plugins/carbon_aggregator_plugin.py
+++ b/lib/twisted/plugins/carbon_aggregator_plugin.py
@@ -3,7 +3,6 @@ from zope.interface import implements
 from twisted.plugin import IPlugin
 from twisted.application.service import IServiceMaker
 
-from carbon import service
 from carbon import conf
 
 
@@ -18,6 +17,7 @@ class CarbonAggregatorServiceMaker(object):
         """
         Construct a C{carbon-aggregator} service.
         """
+        from carbon import service
         return service.createAggregatorService(options)
 
 

--- a/lib/twisted/plugins/carbon_cache_plugin.py
+++ b/lib/twisted/plugins/carbon_cache_plugin.py
@@ -3,7 +3,6 @@ from zope.interface import implements
 from twisted.plugin import IPlugin
 from twisted.application.service import IServiceMaker
 
-from carbon import service
 from carbon import conf
 
 
@@ -18,6 +17,7 @@ class CarbonCacheServiceMaker(object):
         """
         Construct a C{carbon-cache} service.
         """
+        from carbon import service
         return service.createCacheService(options)
 
 

--- a/lib/twisted/plugins/carbon_relay_plugin.py
+++ b/lib/twisted/plugins/carbon_relay_plugin.py
@@ -3,7 +3,6 @@ from zope.interface import implements
 from twisted.plugin import IPlugin
 from twisted.application.service import IServiceMaker
 
-from carbon import service
 from carbon import conf
 
 
@@ -18,6 +17,7 @@ class CarbonRelayServiceMaker(object):
         """
         Construct a C{carbon-relay} service.
         """
+        from carbon import service
         return service.createRelayService(options)
 
 


### PR DESCRIPTION
This pull request has a feature of "Hot data cache" - another whisper storage to keep metrics with short retention time so serve regular monitoring requests. This Hot data location can be put on a in-memory file system so all requests will be served much faster.

Use case: we have a lot of dashboards with time window from -2 hours till now and reading from the regular HDD is slow and expensive. As an alternative we will use this feature. Web app can also read from both of the locations and choose hot data location if it can provide enough data.

Hot data cache has own aggregation and storage schemas setup. My assumption was that storage schema for the hot cache should be a maximum frequency but for few hours only.