### PR TITLE
Fix race condition in carbon client queue full signalling

### DIFF
--- a/lib/carbon/client.py
+++ b/lib/carbon/client.py
@@ -76,7 +76,8 @@ class CarbonClientProtocol(Int32StringReceiver):
       queueSize = self.factory.queueSize
       if (self.factory.queueFull.called and
           queueSize < SEND_QUEUE_LOW_WATERMARK):
-        self.factory.queueHasSpace.callback(queueSize)
+        if not self.factory.queueHasSpace.called:
+          self.factory.queueHasSpace.callback(queueSize)
 
   def __str__(self):
     return 'CarbonClientProtocol(%s:%d:%s)' % (self.factory.destination)


### PR DESCRIPTION
Addresses #383

There appears to be a race that happens when the queue is full and several destinations reconnect at the same time, all send points along, and all try and signal that the queue's no longer full. One of these triggers the callback, but another hits the callback before the first one is complete.

This is a quick check to the callback state to ensure it's not called twice before being reset in this case
