### PR TITLE
Remove log.debug in cache and writer (0.9.x)

### DIFF
--- a/lib/carbon/cache.py
+++ b/lib/carbon/cache.py
@@ -36,7 +36,7 @@ class _MetricCache(defaultdict):
       t = time.time()
       queue = sorted(self.counts, key=lambda x: x[1])
       if settings.LOG_CACHE_QUEUE_SORTS:
-        log.debug("Sorted %d cache queues in %.6f seconds" % (len(queue), time.time() - t))
+        log.msg("Sorted %d cache queues in %.6f seconds" % (len(queue), time.time() - t))
       while queue:
         yield queue.pop()[0]
 

--- a/lib/carbon/writer.py
+++ b/lib/carbon/writer.py
@@ -32,7 +32,7 @@ from twisted.application.service import Service
 try:
     import signal
 except ImportError:
-    log.debug("Couldn't import signal module")
+    log.msg("Couldn't import signal module")
 
 
 SCHEMAS = loadStorageSchemas()
@@ -199,7 +199,7 @@ class WriterService(Service):
 
     def startService(self):
         if 'signal' in globals().keys():
-          log.debug("Installing SIG_IGN for SIGHUP")
+          log.msg("Installing SIG_IGN for SIGHUP")
           signal.signal(signal.SIGHUP, signal.SIG_IGN)
         self.storage_reload_task.start(60, False)
         self.aggregation_reload_task.start(60, False)


### PR DESCRIPTION
The cache and writer don't support log.debug, use log.msg instead. Ported from master. Refs #401.