### PR TITLE
Clear buffers when they are reset.

### DIFF
--- a/lib/carbon/aggregator/buffers.py
+++ b/lib/carbon/aggregator/buffers.py
@@ -96,6 +96,7 @@ class IntervalBuffer:
     self.active = True
 
   def mark_inactive(self):
+    self.values = []
     self.active = False
 
 


### PR DESCRIPTION
The aggregator can use multiple buckets in an aggregation computation. It marks
each bucket as inactive after the computation, but buckets can be reactivated
if new points are added - this can occur if the aggregation computation timing
doesn't align with the bucket boundaries. If that happens, then points will be
re-used between computations, leading to inflated or otherwise incorrect
values. Cleaning buckets after they are used ensures that old data is never
used again even though the bucket may be reused.