### PR TITLE
Skip caching of aggregation transformation output

### DIFF
--- a/lib/carbon/aggregator/rules.py
+++ b/lib/carbon/aggregator/rules.py
@@ -93,7 +93,8 @@ class AggregationRule:
       except TypeError:
         log.err("Failed to interpolate template %s with fields %s" % (self.output_template, extracted_fields))
 
-    self.cache[metric_path] = result
+    if result:
+      self.cache[metric_path] = result
     return result
 
   def build_regex(self):


### PR DESCRIPTION
This was originally merged into master and forgotten about. This pull cherry-picks the change into 0.9.x

Reported in issue #185 via @dkulikovsky
Each aggregation rule caches transformations to avoid unneeded regex
matches. In the case of many rules, each rule will maintain a cache for
every metric it sees, whether or not that metric is matched. This
manifests for some users as a memory leak

Instead, compromise by not caching the negative result, storing only
metric transformations that actually match have an output