### PR TITLE
Fix MetricsCache size leak in 0.9.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ env:
   - TOXENV=py26
   - TOXENV=py27
   - TOXENV=lint
-  - TOXENV=benchmark
 
 before_install:
   # TODO: [jssjr 2014-09-23] Remove this when /opt/graphite isn't hardcoded

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
   - TOXENV=py26
   - TOXENV=py27
   - TOXENV=lint
+  - TOXENV=benchmark
 
 before_install:
   # TODO: [jssjr 2014-09-23] Remove this when /opt/graphite isn't hardcoded

--- a/lib/carbon/aggregator/buffers.py
+++ b/lib/carbon/aggregator/buffers.py
@@ -64,7 +64,7 @@ class MetricBuffer:
         value = self.aggregation_func(buffer.values)
         datapoint = (buffer.interval, value)
         events.metricGenerated(self.metric_path, datapoint)
-        state.instrumentation.increment('aggregateDatapointsSent')
+        instrumentation.increment('aggregateDatapointsSent')
         buffer.mark_inactive()
 
       if buffer.interval < age_threshold:
@@ -103,4 +103,4 @@ class IntervalBuffer:
 BufferManager = BufferManager()
 
 # Avoid import circularity
-from carbon import events, state
+from carbon import events, state, instrumentation

--- a/lib/carbon/aggregator/buffers.py
+++ b/lib/carbon/aggregator/buffers.py
@@ -63,7 +63,7 @@ class MetricBuffer:
       if buffer.active:
         value = self.aggregation_func(buffer.values)
         datapoint = (buffer.interval, value)
-        state.events.metricGenerated(self.metric_path, datapoint)
+        events.metricGenerated(self.metric_path, datapoint)
         state.instrumentation.increment('aggregateDatapointsSent')
         buffer.mark_inactive()
 
@@ -103,4 +103,4 @@ class IntervalBuffer:
 BufferManager = BufferManager()
 
 # Avoid import circularity
-from carbon import state
+from carbon import events, state

--- a/lib/carbon/cache.py
+++ b/lib/carbon/cache.py
@@ -58,6 +58,7 @@ class _MetricCache(defaultdict):
     elif metric:
       datapoints = (metric, super(_MetricCache, self).pop(metric))
     elif not metric and self.method == "max":
+      # TODO: [jssjr 2015-04-24] This is O(n^2) and suuuuuper slow.
       metric = max(self.items(), key=lambda x: len(x[1]))[0]
       datapoints = (metric, super(_MetricCache, self).pop(metric))
     elif not metric and self.method == "naive":

--- a/lib/carbon/cache.py
+++ b/lib/carbon/cache.py
@@ -55,6 +55,8 @@ class _MetricCache(defaultdict):
   def pop(self, metric=None):
     if not self:
       raise KeyError(metric)
+    elif metric:
+      datapoints = (metric, super(_MetricCache, self).pop(metric))
     elif not metric and self.method == "max":
       metric = max(self.items(), key=lambda x: len(x[1]))[0]
       datapoints = (metric, super(_MetricCache, self).pop(metric))

--- a/lib/carbon/cache.py
+++ b/lib/carbon/cache.py
@@ -45,7 +45,7 @@ class _MetricCache(defaultdict):
     self[metric].append(datapoint)
     if self.isFull():
       log.msg("MetricCache is full: self.size=%d" % self.size)
-      state.events.cacheFull()
+      events.cacheFull()
 
   def isFull(self):
     # Short circuit this test if there is no max cache size, then we don't need
@@ -80,4 +80,4 @@ MetricCache = _MetricCache(method=settings.CACHE_WRITE_STRATEGY)
 
 
 # Avoid import circularities
-from carbon import log, state
+from carbon import log, state, events

--- a/lib/carbon/client.py
+++ b/lib/carbon/client.py
@@ -5,7 +5,7 @@ from twisted.internet.protocol import ReconnectingClientFactory
 from twisted.protocols.basic import Int32StringReceiver
 from carbon.conf import settings
 from carbon.util import pickle
-from carbon import log, state, instrumentation
+from carbon import log, events, state, instrumentation
 
 try:
     import signal
@@ -110,7 +110,7 @@ class CarbonClientFactory(ReconnectingClientFactory):
     self.relayMaxQueueLength = 'destinations.%s.relayMaxQueueLength' % self.destinationName
 
   def queueFullCallback(self, result):
-    state.events.cacheFull()
+    events.cacheFull()
     log.clients('%s send queue is full (%d datapoints)' % (self, result))
 
   def queueSpaceCallback(self, result):
@@ -118,7 +118,7 @@ class CarbonClientFactory(ReconnectingClientFactory):
       log.clients('%s send queue has space available' % self.connectedProtocol)
       self.queueFull = Deferred()
       self.queueFull.addCallback(self.queueFullCallback)
-      state.events.cacheSpaceAvailable()
+      events.cacheSpaceAvailable()
     self.queueHasSpace = Deferred()
     self.queueHasSpace.addCallback(self.queueSpaceCallback)
 

--- a/lib/carbon/events.py
+++ b/lib/carbon/events.py
@@ -30,9 +30,9 @@ pauseReceivingMetrics = Event('pauseReceivingMetrics')
 resumeReceivingMetrics = Event('resumeReceivingMetrics')
 
 # Default handlers
-metricReceived.addHandler(lambda metric, datapoint: state.instrumentation.increment('metricsReceived'))
+metricReceived.addHandler(lambda metric, datapoint: carbon.instrumentation.increment('metricsReceived'))
 
-cacheFull.addHandler(lambda: state.instrumentation.increment('cache.overflow'))
+cacheFull.addHandler(lambda: carbon.instrumentation.increment('cache.overflow'))
 cacheFull.addHandler(lambda: setattr(state, 'cacheTooFull', True))
 cacheSpaceAvailable.addHandler(lambda: setattr(state, 'cacheTooFull', False))
 
@@ -41,4 +41,4 @@ resumeReceivingMetrics.addHandler(lambda: setattr(state, 'metricReceiversPaused'
 
 
 # Avoid import circularities
-from carbon import log, state
+from carbon import log

--- a/lib/carbon/events.py
+++ b/lib/carbon/events.py
@@ -29,9 +29,6 @@ cacheSpaceAvailable = Event('cacheSpaceAvailable')
 pauseReceivingMetrics = Event('pauseReceivingMetrics')
 resumeReceivingMetrics = Event('resumeReceivingMetrics')
 
-# Default handlers
-metricReceived.addHandler(lambda metric, datapoint: carbon.instrumentation.increment('metricsReceived'))
-
 cacheFull.addHandler(lambda: carbon.instrumentation.increment('cache.overflow'))
 cacheFull.addHandler(lambda: setattr(state, 'cacheTooFull', True))
 cacheSpaceAvailable.addHandler(lambda: setattr(state, 'cacheTooFull', False))

--- a/lib/carbon/instrumentation.py
+++ b/lib/carbon/instrumentation.py
@@ -116,9 +116,9 @@ def recordMetrics():
   # aggregator metrics
   elif settings.program == 'carbon-aggregator':
     record = aggregator_record
-    record('allocatedBuffers', len(BufferManager))
+    record('allocatedBuffers', len(carbon.aggregator.buffers.BufferManager))
     record('bufferedDatapoints',
-           sum([b.size for b in BufferManager.buffers.values()]))
+           sum([b.size for b in carbon.aggregator.buffers.BufferManager.buffers.values()]))
     record('aggregateDatapointsSent', myStats.get('aggregateDatapointsSent', 0))
 
   # relay metrics
@@ -185,4 +185,3 @@ class InstrumentationService(Service):
 
 # Avoid import circularities
 from carbon import state, events, cache
-from carbon.aggregator.buffers import BufferManager

--- a/lib/carbon/instrumentation.py
+++ b/lib/carbon/instrumentation.py
@@ -171,6 +171,8 @@ def aggregator_record(metric, value):
 class InstrumentationService(Service):
     def __init__(self):
         self.record_task = LoopingCall(recordMetrics)
+        # Default handlers
+        events.metricReceived.addHandler(lambda metric, datapoint: increment('metricsReceived'))
 
     def startService(self):
         if settings.CARBON_METRIC_INTERVAL > 0:

--- a/lib/carbon/service.py
+++ b/lib/carbon/service.py
@@ -24,9 +24,6 @@ from carbon import state, util, events
 from carbon.log import carbonLogObserver
 from carbon.exceptions import CarbonConfigException
 
-state.events = events
-
-
 class CarbonRootService(MultiService):
   """Root Service that properly configures twistd logging"""
 
@@ -40,7 +37,6 @@ def createBaseService(config):
     from carbon.conf import settings
     from carbon import instrumentation
 
-    global state
     state.instrumentation = instrumentation
 
     from carbon.protocols import (MetricLineReceiver, MetricPickleReceiver,

--- a/lib/carbon/service.py
+++ b/lib/carbon/service.py
@@ -35,9 +35,6 @@ class CarbonRootService(MultiService):
 
 def createBaseService(config):
     from carbon.conf import settings
-    from carbon import instrumentation
-
-    state.instrumentation = instrumentation
 
     from carbon.protocols import (MetricLineReceiver, MetricPickleReceiver,
                                   MetricDatagramReceiver)

--- a/lib/carbon/tests/benchmark_cache.py
+++ b/lib/carbon/tests/benchmark_cache.py
@@ -1,0 +1,25 @@
+import timeit
+from mock import Mock
+from carbon.cache import MetricCache, _MetricCache
+
+settings = {
+        'MAX_CACHE_SIZE': float('inf'),
+        'CACHE_SIZE_LOW_WATERMARK': float('inf'),
+        'CACHE_WRITE_STRATEGY': 'naive'
+        }
+metric_cache = _MetricCache(method="naive")
+i=0
+
+def store_command():
+    global i
+    i=i+1
+    return metric_cache.store('foo', (i, 1.0))
+
+if __name__ == '__main__':
+    import timeit
+
+    print("Benchmarking MetricCache.store()...")
+    print("datapoints time")
+    for n in [1000, 10000, 100000, 1000000]:
+        metric_cache = _MetricCache(method="naive")
+        print("%d\t%f" % (n, timeit.timeit(store_command, number=n)))

--- a/lib/carbon/tests/benchmark_cache.py
+++ b/lib/carbon/tests/benchmark_cache.py
@@ -8,18 +8,33 @@ settings = {
         'CACHE_WRITE_STRATEGY': 'naive'
         }
 metric_cache = _MetricCache(method="naive")
-i=0
+i = 0
 
-def store_command():
+def reset(method):
+    i = 0
+    metric_cache = _MetricCache(method=method)
+
+def command_store_foo():
     global i
     i=i+1
     return metric_cache.store('foo', (i, 1.0))
 
+def command_store_foo_n():
+    global i
+    i=i+1
+    return metric_cache.store("foo.%d" % i, (i, 1.0))
+
 if __name__ == '__main__':
     import timeit
 
-    print("Benchmarking MetricCache.store()...")
+    print("Benchmarking single metric MetricCache.store()...")
     print("datapoints time")
     for n in [1000, 10000, 100000, 1000000]:
-        metric_cache = _MetricCache(method="naive")
-        print("%d\t%f" % (n, timeit.timeit(store_command, number=n)))
+        reset("naive")
+        print("%d\t%f" % (n, timeit.timeit(command_store_foo, number=n)))
+
+    print("Benchmarking unique metric MetricCache.store()...")
+    print("datapoints time")
+    for n in [1000, 10000, 100000, 1000000]:
+        reset("naive")
+        print("%d\t%f" % (n, timeit.timeit(command_store_foo_n, number=n)))

--- a/lib/carbon/tests/benchmark_cache.py
+++ b/lib/carbon/tests/benchmark_cache.py
@@ -12,7 +12,6 @@ i = 0
 
 def reset(method):
     i = 0
-    metric_cache = _MetricCache(method=method)
 
 def command_store_foo():
     global i
@@ -24,6 +23,14 @@ def command_store_foo_n():
     i=i+1
     return metric_cache.store("foo.%d" % i, (i, 1.0))
 
+def command_isFull():
+    return metric_cache.isFull()
+
+def command_drain():
+    while metric_cache:
+        metric_cache.pop()
+    return metric_cache.size
+
 if __name__ == '__main__':
     import timeit
 
@@ -31,10 +38,41 @@ if __name__ == '__main__':
     print("datapoints time")
     for n in [1000, 10000, 100000, 1000000]:
         reset("naive")
+        metric_cache = _MetricCache(method="naive")
         print("%d\t%f" % (n, timeit.timeit(command_store_foo, number=n)))
 
     print("Benchmarking unique metric MetricCache.store()...")
     print("datapoints time")
     for n in [1000, 10000, 100000, 1000000]:
         reset("naive")
+        metric_cache = _MetricCache(method="naive")
         print("%d\t%f" % (n, timeit.timeit(command_store_foo_n, number=n)))
+
+    print("Benchmarking MetricCache.isFull()...")
+    print("cache_size time")
+    for n in [1000, 10000, 100000, 1000000]:
+        reset("naive")
+        metric_cache = _MetricCache(method="naive")
+        timeit.timeit(command_store_foo, number=n)
+        print("%d\t%f" % (n, timeit.timeit(command_isFull)))
+
+    print("Benchmarking single metric MetricCache drain...")
+    print("strategy cache_size time end_size")
+    for strategy in ["sorted", "max", "naive"]:
+        for n in [1000, 10000, 100000, 1000000]:
+            reset(strategy)
+            metric_cache = _MetricCache(method=strategy)
+            timeit.timeit(command_store_foo, number=n)
+            print("%s\t%d\t%f\t%d" % (strategy, n, timeit.timeit(command_drain, number=1), metric_cache.size))
+
+    print("Benchmarking unique metric MetricCache drain...")
+    print("strategy cache_size time end_size")
+    for strategy in ["sorted", "max", "naive"]:
+        for n in [1000, 10000, 100000, 1000000]:
+            if strategy == "max" and n > 10000: # remove me when max is fast
+              print("%s\t%d\t%s\t%d" % (strategy, n, 'skipped', 0))
+              continue
+            reset(strategy)
+            metric_cache = _MetricCache(method=strategy)
+            timeit.timeit(command_store_foo_n, number=n)
+            print("%s\t%d\t%f\t%d" % (strategy, n, timeit.timeit(command_drain, number=1), metric_cache.size))

--- a/lib/carbon/tests/test_cache.py
+++ b/lib/carbon/tests/test_cache.py
@@ -19,6 +19,9 @@ class FakeOptions(object):
 
 class MetricCacheIntegrity(MockerTestCase):
 
+    def calculate_size(self, cache):
+        return reduce(lambda x, y: x + len(y), cache.values(), 0)
+
     def test_metrics_cache_init(self):
         """A new metric cache should have zero elements"""
         self.assertEqual(0, MetricCache.size)
@@ -40,6 +43,7 @@ class MetricCacheIntegrity(MockerTestCase):
         self.assertEqual(("d.e.f", deque([datapoint1])), (m, d))
 
         self.assertEqual(0, MetricCache.size)
+        self.assertEqual(0, calculate_size(MetricsCache))
 
     def test_write_strategy_naive(self):
         """Create a metric cache, insert metrics, ensure naive writes"""
@@ -61,6 +65,7 @@ class MetricCacheIntegrity(MockerTestCase):
         cache.pop()
 
         self.assertEqual(0, cache.size)
+        self.assertEqual(0, calculate_size(cache))
 
     def test_write_strategy_max(self):
         """Create a metric cache, insert metrics, ensure naive writes"""
@@ -84,3 +89,4 @@ class MetricCacheIntegrity(MockerTestCase):
         self.assertEqual(("d.e.f", deque([datapoint1])), (m, d))
 
         self.assertEqual(0, cache.size)
+        self.assertEqual(0, calculate_size(cache))

--- a/lib/carbon/tests/test_cache.py
+++ b/lib/carbon/tests/test_cache.py
@@ -50,6 +50,17 @@ class MetricCacheIntegrity(MockerTestCase):
                                ROOT_DIR="foo")
         cache = _MetricCache(method=settings.CACHE_WRITE_STRATEGY)
         self.assertEqual("naive", cache.method)
+        now = time.time()
+        datapoint1 = (now - 10, float(1))
+        datapoint2 = (now, float(2))
+        cache.store("d.e.f", datapoint1)
+        cache.store("a.b.c", datapoint1)
+        cache.store("a.b.c", datapoint2)
+
+        cache.pop()
+        cache.pop()
+
+        self.assertEqual(0, cache.size)
 
     def test_write_strategy_max(self):
         """Create a metric cache, insert metrics, ensure naive writes"""

--- a/lib/carbon/tests/test_cache.py
+++ b/lib/carbon/tests/test_cache.py
@@ -1,6 +1,8 @@
 import time
+import unittest
 from collections import deque
 from mocker import MockerTestCase
+from mock import Mock, PropertyMock, patch
 from carbon.cache import MetricCache, _MetricCache
 from carbon.conf import read_config
 
@@ -114,3 +116,140 @@ class MetricCacheIntegrity(MockerTestCase):
 
         self.assertEqual(0, cache.size)
         self.assertEqual(0, self.calculate_size(cache))
+
+
+class MetricCacheTest(unittest.TestCase):
+  def setUp(self):
+    settings = {
+      'MAX_CACHE_SIZE': float('inf'),
+      'CACHE_SIZE_LOW_WATERMARK': float('inf'),
+      'CACHE_WRITE_STRATEGY': 'naive'
+    }
+    self._settings_patch = patch.dict('carbon.conf.settings', settings)
+    self._settings_patch.start()
+    self.metric_cache = _MetricCache(method="naive")
+
+  def tearDown(self):
+    self._settings_patch.stop()
+
+  def test_cache_is_a_dict(self):
+    self.assertTrue(issubclass(_MetricCache, dict))
+
+  def test_initial_size(self):
+    self.assertEqual(0, self.metric_cache.size)
+
+  def test_store_new_metric(self):
+    self.metric_cache.store('foo', (123456, 1.0))
+    self.assertEqual(1, self.metric_cache.size)
+    self.assertEqual(deque([(123456, 1.0)]), self.metric_cache['foo'])
+
+  def test_store_multiple_datapoints(self):
+    self.metric_cache.store('foo', (123456, 1.0))
+    self.metric_cache.store('foo', (123457, 2.0))
+    self.assertEqual(2, self.metric_cache.size)
+    result = self.metric_cache['foo']
+    self.assertTrue((123456, 1.0) in result)
+    self.assertTrue((123457, 2.0) in result)
+
+  """ TODO: FAILING
+  def test_store_duplicate_timestamp(self):
+    self.metric_cache.store('foo', (123456, 1.0))
+    self.metric_cache.store('foo', (123456, 2.0))
+    self.assertEqual(1, self.metric_cache.size)
+    self.assertEqual([(123456, 2.0)], self.metric_cache['foo'].items())
+  """
+
+  def test_store_checks_fullness(self):
+    is_full_mock = Mock()
+    with patch.object(_MetricCache, 'isFull', is_full_mock):
+      with patch('carbon.cache.events'):
+        metric_cache = _MetricCache()
+        metric_cache.store('foo', (123456, 1.0))
+        is_full_mock.assert_called_once()
+
+  def test_store_on_full_triggers_events(self):
+    is_full_mock = Mock(return_value=True)
+    with patch.object(_MetricCache, 'isFull', is_full_mock):
+      with patch('carbon.cache.events') as events_mock:
+        self.metric_cache.store('foo', (123456, 1.0))
+        events_mock.return_value.cacheFull.assert_called_once()
+
+  def test_pop_multiple_datapoints(self):
+    self.metric_cache.store('foo', (123456, 1.0))
+    self.metric_cache.store('foo', (123457, 2.0))
+    result = self.metric_cache.pop('foo')
+    self.assertTrue((123456, 1.0) in result[1])
+    self.assertTrue((123457, 2.0) in result[1])
+
+  def test_pop_reduces_size(self):
+    self.metric_cache.store('foo', (123456, 1.0))
+    self.metric_cache.store('foo', (123457, 2.0))
+    self.metric_cache.pop('foo')
+    self.assertEqual(0, self.metric_cache.size)
+
+  """ TODO: FAILING
+  def test_pop_returns_sorted_timestamps(self):
+    self.metric_cache.store('foo', (123457, 2.0))
+    self.metric_cache.store('foo', (123458, 3.0))
+    self.metric_cache.store('foo', (123456, 1.0))
+    result = self.metric_cache.pop('foo')
+    expected = [(123456, 1.0), (123457, 2.0), (123458, 3.0)]
+    self.assertEqual(expected, result)
+  """
+
+  def test_pop_raises_on_missing(self):
+    self.assertRaises(KeyError, self.metric_cache.pop, 'foo')
+
+  def test_get_datapoints(self):
+    self.metric_cache.store('foo', (123456, 1.0))
+    self.assertEqual(deque([(123456, 1.0)]), self.metric_cache['foo'])
+
+  def test_get_datapoints_doesnt_pop(self):
+    self.metric_cache.store('foo', (123456, 1.0))
+    self.assertEqual(deque([(123456, 1.0)]), self.metric_cache['foo'])
+    self.assertEqual(1, self.metric_cache.size)
+    self.assertEqual(deque([(123456, 1.0)]), self.metric_cache['foo'])
+
+  def test_get_datapoints_returns_empty_on_missing(self):
+    self.assertEqual(deque([]), self.metric_cache['foo'])
+
+  """ TODO: FAILING
+  def test_get_datapoints_returns_sorted_timestamps(self):
+    self.metric_cache.store('foo', (123457, 2.0))
+    self.metric_cache.store('foo', (123458, 3.0))
+    self.metric_cache.store('foo', (123456, 1.0))
+    result = self.metric_cache['foo']
+    expected = deque([(123456, 1.0), (123457, 2.0), (123458, 3.0)])
+    self.assertEqual(expected, result)
+  """
+
+  def test_is_full_short_circuits_on_inf(self):
+    with patch.object(self.metric_cache, 'size') as size_mock:
+      self.metric_cache.isFull
+      size_mock.assert_not_called()
+
+  def test_is_full(self):
+    self._settings_patch.values['MAX_CACHE_SIZE'] = 2.0
+    self._settings_patch.start()
+    with patch('carbon.cache.events'):
+      self.assertFalse(self.metric_cache.isFull())
+      self.metric_cache.store('foo', (123456, 1.0))
+      self.assertFalse(self.metric_cache.isFull())
+      self.metric_cache.store('foo', (123457, 1.0))
+      self.assertTrue(self.metric_cache.isFull())
+
+  def test_counts_one_datapoint(self):
+    self.metric_cache.store('foo', (123456, 1.0))
+    self.assertEqual([('foo', 1)], self.metric_cache.counts)
+
+  def test_counts_two_datapoints(self):
+    self.metric_cache.store('foo', (123456, 1.0))
+    self.metric_cache.store('foo', (123457, 2.0))
+    self.assertEqual([('foo', 2)], self.metric_cache.counts)
+
+  def test_counts_multiple_datapoints(self):
+    self.metric_cache.store('foo', (123456, 1.0))
+    self.metric_cache.store('foo', (123457, 2.0))
+    self.metric_cache.store('bar', (123458, 3.0))
+    self.assertTrue(('foo', 2) in self.metric_cache.counts)
+    self.assertTrue(('bar', 1) in self.metric_cache.counts)

--- a/lib/carbon/tests/test_cache.py
+++ b/lib/carbon/tests/test_cache.py
@@ -43,7 +43,7 @@ class MetricCacheIntegrity(MockerTestCase):
         self.assertEqual(("d.e.f", deque([datapoint1])), (m, d))
 
         self.assertEqual(0, MetricCache.size)
-        self.assertEqual(0, calculate_size(MetricsCache))
+        self.assertEqual(0, self.calculate_size(MetricCache))
 
     def test_write_strategy_naive(self):
         """Create a metric cache, insert metrics, ensure naive writes"""
@@ -65,7 +65,7 @@ class MetricCacheIntegrity(MockerTestCase):
         cache.pop()
 
         self.assertEqual(0, cache.size)
-        self.assertEqual(0, calculate_size(cache))
+        self.assertEqual(0, self.calculate_size(cache))
 
     def test_write_strategy_max(self):
         """Create a metric cache, insert metrics, ensure naive writes"""
@@ -89,4 +89,4 @@ class MetricCacheIntegrity(MockerTestCase):
         self.assertEqual(("d.e.f", deque([datapoint1])), (m, d))
 
         self.assertEqual(0, cache.size)
-        self.assertEqual(0, calculate_size(cache))
+        self.assertEqual(0, self.calculate_size(cache))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Twisted>=13.2.0
 git+git://github.com/graphite-project/whisper.git@0.9.13#egg=whisper
 mocker==1.1.1
+mock

--- a/tox.ini
+++ b/tox.ini
@@ -25,3 +25,9 @@ deps =
   flake8
 commands =
   flake8 --exit-zero {toxinidir}/lib/carbon
+
+[testenv:benchmark]
+basepython = python2.7
+voting = False
+commands =
+  python {toxinidir}/lib/carbon/tests/benchmark_cache.py


### PR DESCRIPTION
Exploration into a suspected leak in MetricsCache.

Initial indication of a problem came from inspecting the running carbon-cache process.

```
>>> print "%d %d %d" % ( len(MetricCache), MetricCache.size, reduce(lambda x, y: x + len(y), MetricCache.values(), 0) )
4771 5157 5355
```

I started by backporting tests from `master` then working from there, eventually adding some benchmarks available through `tox -e benchmark`. By reorganizing how we handle instrumentation and event includes, I was able to resolve the problem I discovered.

![screenshot 4 24 15 9 57 pm](https://cloud.githubusercontent.com/assets/79608/7331029/17877ea8-eacd-11e4-9e80-645f9963bab8.png)

I'm still verifying this behavior on our staging cluster, but things are looking quite good.

/cc https://github.com/graphite-project/carbon/issues/371 because this fixes the behavior seen there.