### PR TITLE
Fix the logrotate config variable name

### DIFF
--- a/conf/carbon.conf.example
+++ b/conf/carbon.conf.example
@@ -32,7 +32,7 @@
 
 # Enable daily log rotation. If disabled, a new file will be opened whenever the log file path no
 # longer exists (i.e. it is removed or renamed)
-ENABLE_LOGROTATION = True
+ENABLE_LOGROTATE = True
 
 # Specify the user to drop privileges to
 # If this is blank carbon runs as the user that invokes it

--- a/lib/carbon/tests/test_cache.py
+++ b/lib/carbon/tests/test_cache.py
@@ -48,14 +48,14 @@ class MetricCacheTest(TestCase):
       with patch('carbon.cache.events'):
         metric_cache = _MetricCache()
         metric_cache.store('foo', (123456, 1.0))
-        is_full_mock.assert_called_once()
+        self.assertEqual(1, is_full_mock.call_count)
 
   def test_store_on_full_triggers_events(self):
     is_full_mock = PropertyMock(return_value=True)
     with patch.object(_MetricCache, 'is_full', is_full_mock):
       with patch('carbon.cache.events') as events_mock:
         self.metric_cache.store('foo', (123456, 1.0))
-        events_mock.return_value.cacheFull.assert_called_once()
+        events_mock.cacheFull.assert_called_with()
 
   def test_pop_multiple_datapoints(self):
     self.metric_cache.store('foo', (123456, 1.0))
@@ -74,7 +74,7 @@ class MetricCacheTest(TestCase):
     with patch.object(self.metric_cache, '_check_available_space') as check_space_mock:
       self.metric_cache.store('foo', (123456, 1.0))
       self.metric_cache.pop('foo')
-      check_space_mock.assert_called_once()
+      self.assertEqual(1, check_space_mock.call_count)
 
   def test_pop_returns_sorted_timestamps(self):
     self.metric_cache.store('foo', (123457, 2.0))

--- a/lib/carbon/tests/test_rewrite.py
+++ b/lib/carbon/tests/test_rewrite.py
@@ -85,7 +85,7 @@ class TestRewriteRuleManager(TestCase):
     with patch.object(RewriteRuleManager, 'read_rules'):
       with patch.object(RewriteRuleManager.read_task, 'start') as task_start_mock:
         RewriteRuleManager.read_from('foo.conf')
-        task_start_mock.assert_called_once()
+        self.assertEqual(1, task_start_mock.call_count)
 
   def test_read_records_mtime(self):
     import carbon.rewrite


### PR DESCRIPTION
The setting variable that controls whether carbon is doing its own logrotation is called ENABLE_LOGROTATE.

This was incorrectly included in the example carbon config as ENABLE_LOGROTATION.

Also fix failing tests (caused by updated version of mock)