### PR TITLE
Name internal logrotation setting variable consistently

### DIFF
--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -80,7 +80,7 @@ defaults = dict(
   AGGREGATION_RULES='aggregation-rules.conf',
   REWRITE_RULES='rewrite-rules.conf',
   RELAY_RULES='relay-rules.conf',
-  ENABLE_LOGROTATE=True,
+  ENABLE_LOGROTATION=True,
 )
 
 

--- a/lib/carbon/log.py
+++ b/lib/carbon/log.py
@@ -13,7 +13,7 @@ class CarbonLogFile(DailyLogFile):
     DailyLogFile.__init__(self, *args, **kwargs)
     # avoid circular dependencies
     from carbon.conf import settings
-    self.enableRotation = settings.ENABLE_LOGROTATE
+    self.enableRotation = settings.ENABLE_LOGROTATION
 
   def shouldRotate(self):
     if self.enableRotation:


### PR DESCRIPTION
The internal logrotation setting was renamed for the 0.9.x version from ENABLE_LOGROTATE to ENABLE_LOGROTATION, but the changes were only partially applied to master.