### PR TITLE
Include METRIC_CLIENT_IDLE_TIMEOUT for all daemon types

### DIFF
--- a/conf/carbon.conf.example
+++ b/conf/carbon.conf.example
@@ -30,10 +30,6 @@
 #
 #LOCAL_DATA_DIR = /opt/graphite/storage/whisper/
 
-# If enabled this setting is used to timeout metric client connection if no
-# metrics have been sent in specified time in seconds 
-#METRIC_CLIENT_IDLE_TIMEOUT = None
-
 # Enable daily log rotation. If disabled, a new file will be opened whenever the log file path no
 # longer exists (i.e. it is removed or renamed)
 ENABLE_LOGROTATION = True
@@ -103,6 +99,10 @@ CACHE_QUERY_PORT = 7002
 # over which metrics are received will temporarily stop accepting
 # data until the cache size falls below 95% MAX_CACHE_SIZE.
 USE_FLOW_CONTROL = True
+
+# If enabled this setting is used to timeout metric client connection if no
+# metrics have been sent in specified time in seconds 
+#METRIC_CLIENT_IDLE_TIMEOUT = None
 
 # By default, carbon-cache will log every whisper update and cache hit. This can be excessive and
 # degrade performance if logging on the same volume as the whisper data is stored.
@@ -298,6 +298,10 @@ TIME_TO_DEFER_SENDING = 0.0001
 # data until the send queues fall below QUEUE_LOW_WATERMARK_PCT * MAX_QUEUE_SIZE.
 USE_FLOW_CONTROL = True
 
+# If enabled this setting is used to timeout metric client connection if no
+# metrics have been sent in specified time in seconds 
+#METRIC_CLIENT_IDLE_TIMEOUT = None
+
 # Set this to True to enable whitelisting and blacklisting of metrics in
 # CONF_DIR/whitelist.conf and CONF_DIR/blacklist.conf. If the whitelist is
 # missing or empty, all metrics will pass through
@@ -386,6 +390,10 @@ MAX_QUEUE_SIZE = 10000
 # default) then sockets over which metrics are received will temporarily stop accepting
 # data until the send queues fall below 80% MAX_QUEUE_SIZE.
 USE_FLOW_CONTROL = True
+
+# If enabled this setting is used to timeout metric client connection if no
+# metrics have been sent in specified time in seconds 
+#METRIC_CLIENT_IDLE_TIMEOUT = None
 
 # This defines the maximum "message size" between carbon daemons.
 # You shouldn't need to tune this unless you really know what you're doing.


### PR DESCRIPTION
As introduced in #429.