### PR TITLE
Restore LOG_AGGREGATOR_MISSES functionality

### DIFF
--- a/lib/carbon/aggregator/processor.py
+++ b/lib/carbon/aggregator/processor.py
@@ -3,6 +3,8 @@ from carbon.aggregator.buffers import BufferManager
 from carbon.instrumentation import increment
 from carbon.pipeline import Processor
 from carbon.rewrite import PRE, POST, RewriteRuleManager
+from carbon.conf import settings
+from carbon import log
 
 
 class AggregationProcessor(Processor):
@@ -35,4 +37,6 @@ class AggregationProcessor(Processor):
       metric = rule.apply(metric)
 
     if metric not in aggregate_metrics:
+      if settings.LOG_AGGREGATOR_MISSES and len(aggregate_metrics) == 0:
+        log.msg("Couldn't match metric %s with any aggregation rule. Passing on un-aggregated." % metric)
       yield (metric, datapoint)


### PR DESCRIPTION
This restores the `LOG_AGGREGATOR_MISSES` feature that was proposed in #140, rebased in #239, finally merged in #336, and inadvertently removed during the processor refactor in #358.

Holy crap.