### PR TITLE
Add unit tests for storage module

### DIFF
--- a/lib/carbon/tests/data/conf-directory/storage-aggregation.conf
+++ b/lib/carbon/tests/data/conf-directory/storage-aggregation.conf
@@ -1,0 +1,32 @@
+# Aggregation methods for whisper files. Entries are scanned in order,
+# and first match wins. This file is scanned for changes every 60 seconds
+#
+#  [name]
+#  pattern = <regex>
+#  xFilesFactor = <float between 0 and 1>
+#  aggregationMethod = <average|sum|last|max|min>
+#
+#  name: Arbitrary unique name for the rule
+#  pattern: Regex pattern to match against the metric name
+#  xFilesFactor: Ratio of valid data points required for aggregation to the next retention to occur
+#  aggregationMethod: function to apply to data points for aggregation
+#
+[min]
+pattern = \.min$
+xFilesFactor = 0.1
+aggregationMethod = min
+
+[max]
+pattern = \.max$
+xFilesFactor = 0.1
+aggregationMethod = max
+
+[sum]
+pattern = \.count$
+xFilesFactor = 0
+aggregationMethod = sum
+
+[default_average]
+pattern = .*
+xFilesFactor = 0.5
+aggregationMethod = average

--- a/lib/carbon/tests/data/conf-directory/storage-schemas.conf
+++ b/lib/carbon/tests/data/conf-directory/storage-schemas.conf
@@ -1,0 +1,7 @@
+[carbon]
+pattern = ^carbon\.
+retentions = 60:90d
+
+[default_1min_for_1day]
+pattern = .*
+retentions = 60s:1d

--- a/lib/carbon/tests/test_storage.py
+++ b/lib/carbon/tests/test_storage.py
@@ -1,0 +1,107 @@
+import os
+from unittest import TestCase
+from mock import patch
+
+
+# class NoConfigSchemaLoadingTest(TestCase):
+
+#     def setUp(self):
+#         settings = {
+#             'CONF_DIR': '',
+#         }
+#         self._settings_patch = patch.dict('carbon.conf.settings', settings)
+#         self._settings_patch.start()
+
+#     def tearDown(self):
+#         self._settings_patch.stop()
+
+#     def test_loadAggregationSchemas_load_default_schema(self):
+#         from carbon.storage import loadAggregationSchemas, defaultAggregation
+#         schema_list = loadAggregationSchemas()
+#         self.assertEquals(len(schema_list), 1)
+#         schema = schema_list[0]
+#         self.assertEquals(schema, defaultAggregation)
+
+#     def test_loadStorageSchemas_raise_CarbonConfigException(self):
+#         from carbon.storage import loadStorageSchemas
+#         from carbon.exceptions import CarbonConfigException
+#         with self.assertRaises(CarbonConfigException):
+#             loadStorageSchemas()
+
+
+class ExistingConfigSchemaLoadingTest(TestCase):
+
+    def setUp(self):
+        test_directory = os.path.dirname(os.path.realpath(__file__))
+        settings = {
+            'CONF_DIR': os.path.join(test_directory, 'data', 'conf-directory'),
+        }
+        self._settings_patch = patch.dict('carbon.conf.settings', settings)
+        self._settings_patch.start()
+
+    def tearDown(self):
+        self._settings_patch.stop()
+
+    def test_loadStorageSchemas_return_schemas(self):
+        from carbon.storage import loadStorageSchemas, PatternSchema, Archive
+        schema_list = loadStorageSchemas()
+        self.assertEquals(len(schema_list), 3)
+        expected = [
+            PatternSchema('carbon', '^carbon\.', [Archive.fromString('60:90d')]),
+            PatternSchema('default_1min_for_1day', '.*', [Archive.fromString('60s:1d')])
+        ]
+        for schema, expected_schema in zip(schema_list[:-1], expected):
+            self.assertEquals(schema.name, expected_schema.name)
+            self.assertEquals(schema.pattern, expected_schema.pattern)
+            for (archive, expected_archive) in zip(schema.archives, expected_schema.archives):
+                self.assertEquals(archive.getTuple(), expected_archive.getTuple())
+
+    def test_loadStorageSchemas_return_the_default_schema_last(self):
+        from carbon.storage import loadStorageSchemas, defaultSchema
+        schema_list = loadStorageSchemas()
+        last_schema = schema_list[-1]
+        self.assertEquals(last_schema.name, defaultSchema.name)
+        self.assertEquals(last_schema.archives, defaultSchema.archives)
+
+    def test_loadAggregationSchemas_return_schemas(self):
+        from carbon.storage import loadAggregationSchemas, PatternSchema
+        schema_list = loadAggregationSchemas()
+        self.assertEquals(len(schema_list), 5)
+        expected = [
+            PatternSchema('min', '\.min$', (0.1, 'min')),
+            PatternSchema('max', '\.max$', (0.1, 'max')),
+            PatternSchema('sum', '\.count$', (0, 'sum')),
+            PatternSchema('default_average', '.*', (0.5, 'average'))
+        ]
+        for schema, expected_schema in zip(schema_list[:-1], expected):
+            self.assertEquals(schema.name, expected_schema.name)
+            self.assertEquals(schema.pattern, expected_schema.pattern)
+            self.assertEquals(schema.archives, expected_schema.archives)
+
+    def test_loadAggregationSchema_return_the_default_schema_last(self):
+        from carbon.storage import loadAggregationSchemas, defaultAggregation
+        schema_list = loadAggregationSchemas()
+        last_schema = schema_list[-1]
+        self.assertEquals(last_schema, defaultAggregation)
+
+
+class getFilesystemPathTest(TestCase):
+
+    def setUp(self):
+        self._sep_patch = patch.object(os.path, 'sep', "/")
+        self._sep_patch.start()
+        settings = {
+            'LOCAL_DATA_DIR': '/tmp/',
+            'CONF_DIR': '',
+        }
+        self._settings_patch = patch.dict('carbon.conf.settings', settings)
+        self._settings_patch.start()
+
+    def tearDown(self):
+        self._settings_patch.stop()
+        self._sep_patch.stop()
+
+    def test_getFilesystemPath(self):
+        from carbon.storage import getFilesystemPath
+        result = getFilesystemPath('stats.example.counts')
+        self.assertEquals(result, '/tmp/stats/example/counts.wsp')


### PR DESCRIPTION
As I was trying to track down either a bug in Carbon parsing or a mistake in my `storage-aggregation.conf` file (for the story, it turned out my carbon deamon just had to be restarted :-°), I ended up writing this test suite for the storage module.

The all `NoConfigSchemaLoadingTest` class, whose purpose is to test what happens when `CONF_DIR` leads nowhere, is commented out though. For some reason, the mock of `carbon.conf.settings` persists between classes. (if I test  `NoConfigSchemaLoadingTest` by itself it works fine). I have fiddled around with trying to `reload(carbon.conf)` in setUp or tearDown but to no avail. Maybe someone will have a better idea? Otherwise I suppose it’s fine removing this test class alltogether.

Hope that helps!