### PR TITLE
Events.py: add state import back for event tracking

### DIFF
--- a/lib/carbon/events.py
+++ b/lib/carbon/events.py
@@ -38,4 +38,4 @@ resumeReceivingMetrics.addHandler(lambda: setattr(state, 'metricReceiversPaused'
 
 
 # Avoid import circularities
-from carbon import log
+from carbon import log, state


### PR DESCRIPTION
Fixes:

```
17/11/2015 20:40:18 :: Starting factory CarbonClientFactory(127.0.0.1:2034:c)
17/11/2015 20:40:19 :: Exception in cacheSpaceAvailable event handler: args=() kwargs={}
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/twisted/internet/defer.py", line 362, in callback
    self._startRunCallbacks(result)
  File "/usr/local/lib/python2.7/dist-packages/twisted/internet/defer.py", line 458, in _startRunCallbacks
    self._runCallbacks()
  File "/usr/local/lib/python2.7/dist-packages/twisted/internet/defer.py", line 545, in _runCallbacks
    current.result = callback(current.result, *args, **kw)
  File "/opt/graphite/lib/carbon/client.py", line 122, in queueSpaceCallback
    events.cacheSpaceAvailable()
--- <exception caught here> ---
  File "/opt/graphite/lib/carbon/events.py", line 20, in __call__
    handler(*args, **kwargs)
  File "/opt/graphite/lib/carbon/events.py", line 34, in <lambda>
    cacheSpaceAvailable.addHandler(lambda: setattr(state, 'cacheTooFull', False))
exceptions.NameError: global name 'state' is not defined
```

Lines needing state:
https://github.com/graphite-project/carbon/blob/0.9.14/lib/carbon/events.py#L33-L37

Original change:
https://github.com/graphite-project/carbon/commit/7e1d37baf37939a8ae40f0fbe9d34ae25740dabd