### PR TITLE
Fix STORAGE_DIR

### DIFF
--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -547,15 +547,19 @@ def read_config(program, options, **kwargs):
                         os.environ.get("GRAPHITE_STORAGE_DIR",
                                        join(graphite_root, "storage")))
 
-    # By default, everything is written to subdirectories of the storage dir.
-    settings.setdefault(
-        "PID_DIR", settings["STORAGE_DIR"])
-    settings.setdefault(
-        "LOG_DIR", join(settings["STORAGE_DIR"], "log", program))
-    settings.setdefault(
-        "LOCAL_DATA_DIR", join(settings["STORAGE_DIR"], "whisper"))
-    settings.setdefault(
-        "WHITELISTS_DIR", join(settings["STORAGE_DIR"], "lists"))
+    def update_STORAGE_DIR_deps():
+        # By default, everything is written to subdirectories of the storage dir.
+        settings.setdefault(
+            "PID_DIR", settings["STORAGE_DIR"])
+        settings.setdefault(
+            "LOG_DIR", join(settings["STORAGE_DIR"], "log", program))
+        settings.setdefault(
+            "LOCAL_DATA_DIR", join(settings["STORAGE_DIR"], "whisper"))
+        settings.setdefault(
+            "WHITELISTS_DIR", join(settings["STORAGE_DIR"], "lists"))
+
+
+    update_STORAGE_DIR_deps()
 
     # Read configuration options from program-specific section.
     section = program[len("carbon-"):]
@@ -586,4 +590,5 @@ def read_config(program, options, **kwargs):
             join(settings["PID_DIR"], '%s.pid' % program))
         settings["LOG_DIR"] = (options["logdir"] or settings["LOG_DIR"])
 
+    update_STORAGE_DIR_deps()
     return settings

--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -559,7 +559,6 @@ def read_config(program, options, **kwargs):
             "WHITELISTS_DIR", join(settings["STORAGE_DIR"], "lists"))
 
 
-    update_STORAGE_DIR_deps()
 
     # Read configuration options from program-specific section.
     section = program[len("carbon-"):]
@@ -570,6 +569,7 @@ def read_config(program, options, **kwargs):
 
     settings.readFrom(config, section)
     settings.setdefault("instance", options["instance"])
+    update_STORAGE_DIR_deps()
 
     # If a specific instance of the program is specified, augment the settings
     # with the instance-specific settings and provide sane defaults for

--- a/lib/carbon/tests/test_conf.py
+++ b/lib/carbon/tests/test_conf.py
@@ -353,3 +353,59 @@ class ReadConfigTest(MockerTestCase):
                         pidfile=None, logdir=None),
             ROOT_DIR="foo")
         self.assertEqual("boo/carbon-foo-x", settings.LOG_DIR)
+
+    def test_pid_dir_depends_on_storage_dir(self):
+        """
+        Tests 'STORAGE_DIR' dependency 'PID_DIR'
+        """
+        config = self.makeFile(
+            content=("[foo]\n"
+                     "STORAGE_DIR = bar"))
+        settings = read_config(
+            "carbon-foo",
+            FakeOptions(config=config, instance=None,
+                        pidfile=None, logdir=None),
+            ROOT_DIR="foo")
+        self.assertEqual("bar", settings.PID_DIR)
+
+    def test_log_dir_depends_on_storage_dir(self):
+        """
+        Tests 'STORAGE_DIR' dependency 'LOG_DIR'
+        """
+        config = self.makeFile(
+            content=("[foo]\n"
+                     "STORAGE_DIR = bar"))
+        settings = read_config(
+            "carbon-foo",
+            FakeOptions(config=config, instance=None,
+                        pidfile=None, logdir=None),
+            ROOT_DIR="foo")
+        self.assertEqual(join("bar", "log", "carbon-foo"), settings.LOG_DIR)
+
+    def test_local_data_dir_depends_on_storage_dir(self):
+        """
+        Tests 'STORAGE_DIR' dependency 'LOCAL_DATA_DIR'
+        """
+        config = self.makeFile(
+            content=("[foo]\n"
+                     "STORAGE_DIR = bar"))
+        settings = read_config(
+            "carbon-foo",
+            FakeOptions(config=config, instance=None,
+                        pidfile=None, logdir=None),
+            ROOT_DIR="foo")
+        self.assertEqual(join("bar", "whisper"), settings.LOCAL_DATA_DIR)
+
+    def test_whitelists_dir_depends_on_storage_dir(self):
+        """
+        Tests 'STORAGE_DIR' dependency 'WHITELISTS_DIR'
+        """
+        config = self.makeFile(
+            content=("[foo]\n"
+                     "STORAGE_DIR = bar"))
+        settings = read_config(
+            "carbon-foo",
+            FakeOptions(config=config, instance=None,
+                        pidfile=None, logdir=None),
+            ROOT_DIR="foo")
+        self.assertEqual(join("bar", "lists"), settings.WHITELISTS_DIR)


### PR DESCRIPTION
Some settings' defaults refer to STORAGE_DIR, e.g PID_DIR. These are
setdefault'ed using the STORAGE_DIR from before the config is read, i.e.
the defaults. The settings that depend on STORAGE_DIR must be
setdefault'ed each time the config file has been read.

This should fix #269 

It is perhaps not the best style. My initial fix was to move the STORAGE_DIR dependent setdefault's to the bottom of the function, but I found out some code above used LOG_DIR and PID_DIR.

I don't feel this is the correct solution, but it seems to fix #269 for now. At least it shows the cause(!)