### PR TITLE
changed the "Sorted" log messages into debug messages

### DIFF
--- a/lib/carbon/cache.py
+++ b/lib/carbon/cache.py
@@ -71,7 +71,7 @@ class SortedStrategy(DrainStrategy):
       while True:
         t = time.time()
         metric_counts = sorted(self.cache.counts, key=lambda x: x[1])
-        log.msg("Sorted %d cache queues in %.6f seconds" % (len(metric_counts), time.time() - t))
+        log.debug("Sorted %d cache queues in %.6f seconds" % (len(metric_counts), time.time() - t))
         while metric_counts:
           yield itemgetter(0)(metric_counts.pop())
 


### PR DESCRIPTION
Our "console.log" gets full very quickly with messages like:

02/12/2015 08:50:30 :: Sorted 349 cache queues in 0.000427 seconds

These should be treated as debug messages.