### PR TITLE
Stop testing python2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 # http://travis-ci.org/#!/graphite-project/carbon
 language: python
 python:
-    - 2.6
     - 2.7
 
 env:


### PR DESCRIPTION
Twisted 15.5 officially breaks Python 2.6 support so let's stop testing it.

refs https://github.com/graphite-project/carbon/issues/482