### PR TITLE
Stop testing python2.6 (0.9.x)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 language: python
 
 env:
-  - TOXENV=py26
   - TOXENV=py27
   - TOXENV=lint
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,10 +8,6 @@ deps =
 commands =
   trial carbon
 
-# Run tests for python 2.6
-[testenv:py26]
-basepython = python2.6
-
 # Run tests for python 2.7
 [testenv:py27]
 basepython = python2.7


### PR DESCRIPTION
Twisted 15.5 officially breaks Python 2.6 support so let's stop testing it.

refs https://github.com/graphite-project/carbon/issues/482