### PR TITLE
Cherry-pick Whitespace/Flake8 changes from 0.9.x branch

### DIFF
--- a/lib/carbon/client.py
+++ b/lib/carbon/client.py
@@ -169,7 +169,7 @@ class CarbonClientFactory(ReconnectingClientFactory):
     self.addr = (self.host, self.port)
     self.started = False
     # This factory maintains protocol state across reconnects
-    self.queue = deque() # Change to make this the sole source of metrics to be sent.
+    self.queue = deque()  # Change to make this the sole source of metrics to be sent.
     self.connectedProtocol = None
     self.queueEmpty = Deferred()
     self.queueFull = Deferred()
@@ -213,7 +213,7 @@ class CarbonClientFactory(ReconnectingClientFactory):
     self.connectedProtocol.factory = self
     return self.connectedProtocol
 
-  def startConnecting(self): # calling this startFactory yields recursion problems
+  def startConnecting(self):  # calling this startFactory yields recursion problems
     self.started = True
     self.connector = reactor.connectTCP(self.host, self.port, self)
 
@@ -332,7 +332,7 @@ class CarbonClientFactory(ReconnectingClientFactory):
 class CarbonClientManager(Service):
   def __init__(self, router):
     self.router = router
-    self.client_factories = {} # { destination : CarbonClientFactory() }
+    self.client_factories = {}  # { destination : CarbonClientFactory() }
 
   def startService(self):
     if 'signal' in globals().keys():
@@ -359,7 +359,7 @@ class CarbonClientManager(Service):
         fireOnOneCallback=True,
         fireOnOneErrback=True)
     if self.running:
-      factory.startConnecting() # this can trigger & replace connectFailed
+      factory.startConnecting()  # this can trigger & replace connectFailed
 
     return connectAttempted
 
@@ -382,7 +382,7 @@ class CarbonClientManager(Service):
   def stopAllClients(self):
     deferreds = []
     for destination in list(self.client_factories):
-      deferreds.append( self.stopClient(destination) )
+      deferreds.append(self.stopClient(destination))
     return DeferredList(deferreds)
 
   def sendDatapoint(self, metric, datapoint):

--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -146,17 +146,17 @@ class Settings(dict):
     if not parser.has_section(section):
       return
 
-    for key,value in parser.items(section):
+    for key, value in parser.items(section):
       key = key.upper()
 
       # Detect type from defaults dict
       if key in defaults:
-        valueType = type( defaults[key] )
+        valueType = type(defaults[key])
       else:
         valueType = str
 
       if valueType is list:
-        value = [ v.strip() for v in value.split(',') ]
+        value = [v.strip() for v in value.split(',')]
 
       elif valueType is bool:
         value = parser.getboolean(section, key)

--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -92,9 +92,6 @@ defaults = dict(
 )
 
 
-def _umask(value):
-    return int(value, 8)
-
 def _process_alive(pid):
     if exists("/proc"):
         return exists("/proc/%d" % pid)

--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -576,7 +576,7 @@ def read_config(program, options, **kwargs):
                  (program, options["instance"])))
         settings["LOG_DIR"] = (options["logdir"] or
                               join(settings["LOG_DIR"],
-                                "%s-%s" % (program ,options["instance"])))
+                                "%s-%s" % (program, options["instance"])))
     else:
         settings["pidfile"] = (
             options["pidfile"] or

--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -121,14 +121,14 @@ class OrderedConfigParser(ConfigParser):
       line = line.strip()
 
       if line.startswith('[') and line.endswith(']'):
-        sections.append( line[1:-1] )
+        sections.append(line[1:-1])
 
     self._ordered_sections = sections
 
     return result
 
   def sections(self):
-    return list( self._ordered_sections ) # return a copy for safety
+    return list(self._ordered_sections)  # return a copy for safety
 
 
 class Settings(dict):
@@ -182,7 +182,7 @@ class CarbonCacheOptions(usage.Options):
 
     optFlags = [
         ["debug", "", "Run in debug mode."],
-        ]
+    ]
 
     optParameters = [
         ["config", "c", None, "Use the given config file."],
@@ -190,7 +190,7 @@ class CarbonCacheOptions(usage.Options):
         ["logdir", "", None, "Write logs to the given directory."],
         ["whitelist", "", None, "List of metric patterns to allow."],
         ["blacklist", "", None, "List of metric patterns to disallow."],
-        ]
+    ]
 
     def postOptions(self):
         global settings

--- a/lib/carbon/hashing.py
+++ b/lib/carbon/hashing.py
@@ -14,7 +14,7 @@ class ConsistentHashRing:
       self.add_node(node)
 
   def compute_ring_position(self, key):
-    big_hash = md5( str(key) ).hexdigest()
+    big_hash = md5(str(key)).hexdigest()
     small_hash = int(big_hash[:4], 16)
     return small_hash
 

--- a/lib/carbon/instrumentation.py
+++ b/lib/carbon/instrumentation.py
@@ -10,7 +10,7 @@ from carbon.conf import settings
 
 stats = {}
 prior_stats = {}
-HOSTNAME = socket.gethostname().replace('.','_')
+HOSTNAME = socket.gethostname().replace('.', '_')
 PAGESIZE = os.sysconf('SC_PAGESIZE')
 rusage = getrusage(RUSAGE_SELF)
 lastUsage = rusage.ru_utime + rusage.ru_stime
@@ -54,7 +54,7 @@ def getCpuUsage():
   usageDiff = currentUsage - lastUsage
   timeDiff = currentTime - lastUsageTime
 
-  if timeDiff == 0: #shouldn't be possible, but I've actually seen a ZeroDivisionError from this
+  if timeDiff == 0:  # shouldn't be possible, but I've actually seen a ZeroDivisionError from this
     timeDiff = 0.000001
 
   cpuUsagePercent = (usageDiff / timeDiff) * 100.0
@@ -66,7 +66,7 @@ def getCpuUsage():
 
 
 def getMemUsage():
-  rss_pages = int( open('/proc/self/statm').read().split()[1] )
+  rss_pages = int(open('/proc/self/statm').read().split()[1])
   return rss_pages * PAGESIZE
 
 
@@ -146,7 +146,7 @@ def recordMetrics():
   prior_stats.clear()
   prior_stats.update(myPriorStats)
 
-  try: # This only works on Linux
+  try:  # This only works on Linux
     record('memUsage', getMemUsage())
   except Exception:
     pass
@@ -161,6 +161,7 @@ def cache_record(metric, value):
     datapoint = (time.time(), value)
     cache.MetricCache.store(fullMetric, datapoint)
 
+
 def relay_record(metric, value):
     prefix = settings.CARBON_METRIC_PREFIX
     if settings.instance is None:
@@ -169,6 +170,7 @@ def relay_record(metric, value):
       fullMetric = '%s.relays.%s-%s.%s' % (prefix, HOSTNAME, settings.instance, metric)
     datapoint = (time.time(), value)
     events.metricGenerated(fullMetric, datapoint)
+
 
 def aggregator_record(metric, value):
     prefix = settings.CARBON_METRIC_PREFIX

--- a/lib/carbon/log.py
+++ b/lib/carbon/log.py
@@ -58,6 +58,7 @@ class CarbonLogFile(DailyLogFile):
     self.close()
     self._openFile()
 
+
 class CarbonLogObserver(object):
   implements(ILogObserver)
 
@@ -69,6 +70,7 @@ class CarbonLogObserver(object):
 
   def log_to_syslog(self, prefix):
     observer = SyslogObserver(prefix).emit
+
     def syslog_observer(event):
       event["system"] = event.get("type", "console")
       observer(event)
@@ -78,7 +80,7 @@ class CarbonLogObserver(object):
     return self.observer(event)
 
   def stdout_observer(self, event):
-    stdout.write( formatEvent(event, includeType=True) + '\n' )
+    stdout.write(formatEvent(event, includeType=True) + '\n')
     stdout.flush()
 
   def logdir_observer(self, event):
@@ -116,46 +118,58 @@ logToDir = carbonLogObserver.log_to_dir
 
 logToSyslog = carbonLogObserver.log_to_syslog
 
+
 def logToStdout():
   startLoggingWithObserver(carbonLogObserver)
+
 
 def cache(message, **context):
   context['type'] = 'cache'
   msg(message, **context)
 
+
 def clients(message, **context):
   context['type'] = 'clients'
   msg(message, **context)
+
 
 def creates(message, **context):
   context['type'] = 'creates'
   msg(message, **context)
 
+
 def updates(message, **context):
   context['type'] = 'updates'
   msg(message, **context)
+
 
 def listener(message, **context):
   context['type'] = 'listener'
   msg(message, **context)
 
+
 def relay(message, **context):
   context['type'] = 'relay'
   msg(message, **context)
+
 
 def aggregator(message, **context):
   context['type'] = 'aggregator'
   msg(message, **context)
 
+
 def query(message, **context):
   context['type'] = 'query'
   msg(message, **context)
+
 
 def debug(message, **context):
   if debugEnabled:
     msg(message, **context)
 
 debugEnabled = False
+
+
 def setDebugEnabled(enabled):
   global debugEnabled
   debugEnabled = enabled

--- a/lib/carbon/management.py
+++ b/lib/carbon/management.py
@@ -1,7 +1,6 @@
 import traceback
 from carbon import log, state
 
-
 def getMetadata(metric, key):
   try:
     value = state.database.getMetadata(metric, key)

--- a/lib/carbon/manhole.py
+++ b/lib/carbon/manhole.py
@@ -21,6 +21,7 @@ class PublicKeyChecker(SSHPublicKeyDatabase):
       keyBlob = self.userKeys[credentials.username]
       return keyBlob == credentials.blob
 
+
 def createManholeListener():
   sshRealm = TerminalRealm()
   sshRealm.chainedProtocolFactory.protocolFactory = lambda _: Manhole(namespace)
@@ -30,7 +31,7 @@ def createManholeListener():
     credChecker.addUser(settings.MANHOLE_USER, '')
   else:
     userKeys = {
-        settings.MANHOLE_USER : settings.MANHOLE_PUBLIC_KEY,
+        settings.MANHOLE_USER: settings.MANHOLE_PUBLIC_KEY,
     }
     credChecker = PublicKeyChecker(userKeys)
 
@@ -38,6 +39,7 @@ def createManholeListener():
   sshPortal.registerChecker(credChecker)
   sessionFactory = ConchFactory(sshPortal)
   return sessionFactory
+
 
 def start():
     sessionFactory = createManholeListener()

--- a/lib/carbon/protocols.py
+++ b/lib/carbon/protocols.py
@@ -1,6 +1,6 @@
 import time
 
-from twisted.internet import reactor
+#from twisted.internet import reactor
 from twisted.internet.protocol import DatagramProtocol
 from twisted.internet.error import ConnectionDone
 from twisted.protocols.basic import LineOnlyReceiver, Int32StringReceiver
@@ -62,9 +62,9 @@ class MetricReceiver(TimeoutMixin):
     if WhiteList and metric not in WhiteList:
       instrumentation.increment('whitelistRejects')
       return
-    if datapoint[1] != datapoint[1]: # filter out NaN values
+    if datapoint[1] != datapoint[1]:  # filter out NaN values
       return
-    if int(datapoint[0]) == -1: # use current time if none given: https://github.com/graphite-project/carbon/issues/54
+    if int(datapoint[0]) == -1:  # use current time if none given: https://github.com/graphite-project/carbon/issues/54
       datapoint = (time.time(), datapoint[1])
     
     events.metricReceived(metric, datapoint)
@@ -92,7 +92,7 @@ class MetricDatagramReceiver(MetricReceiver, DatagramProtocol):
     for line in data.splitlines():
       try:
         metric, value, timestamp = line.strip().split()
-        datapoint = ( float(timestamp), float(value) )
+        datapoint = (float(timestamp), float(value))
 
         self.metricReceived(metric, datapoint)
       except ValueError:
@@ -117,7 +117,7 @@ class MetricPickleReceiver(MetricReceiver, Int32StringReceiver):
 
     for (metric, datapoint) in datapoints:
       try:
-        datapoint = ( float(datapoint[0]), float(datapoint[1]) ) #force proper types
+        datapoint = (float(datapoint[0]), float(datapoint[1]))  #force proper types
       except ValueError:
         continue
 

--- a/lib/carbon/relayrules.py
+++ b/lib/carbon/relayrules.py
@@ -11,7 +11,7 @@ class RelayRule:
     self.continue_matching = continue_matching
 
   def matches(self, metric):
-    return bool( self.condition(metric) )
+    return bool(self.condition(metric))
 
 
 def loadRelayRules(path):
@@ -46,7 +46,7 @@ def loadRelayRules(path):
 
     if parser.has_option(section, 'default'):
       if not parser.getboolean(section, 'default'):
-        continue # just ignore default = false
+        continue  # just ignore default = false
       if defaultRule:
         raise CarbonConfigException("Only one default rule can be specified")
       defaultRule = RelayRule(condition=lambda metric: True,

--- a/lib/carbon/routers.py
+++ b/lib/carbon/routers.py
@@ -51,15 +51,15 @@ class ConsistentHashingRouter(DatapointRouter):
     (server, port, instance) = destination
     if (server, instance) in self.instance_ports:
       raise Exception("destination instance (%s, %s) already configured" % (server, instance))
-    self.instance_ports[ (server, instance) ] = port
-    self.ring.add_node( (server, instance) )
+    self.instance_ports[(server, instance)] = port
+    self.ring.add_node((server, instance))
 
   def removeDestination(self, destination):
     (server, port, instance) = destination
     if (server, instance) not in self.instance_ports:
       raise Exception("destination instance (%s, %s) not configured" % (server, instance))
-    del self.instance_ports[ (server, instance) ]
-    self.ring.remove_node( (server, instance) )
+    del self.instance_ports[(server, instance)]
+    self.ring.remove_node((server, instance))
 
   def getDestinations(self, metric):
     key = self.getKey(metric)

--- a/lib/carbon/storage.py
+++ b/lib/carbon/storage.py
@@ -12,7 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License."""
 
-import os, re
+import os
+import re
 import whisper
 
 from os.path import join, exists
@@ -26,6 +27,7 @@ STORAGE_SCHEMAS_CONFIG = join(settings.CONF_DIR, 'storage-schemas.conf')
 STORAGE_AGGREGATION_CONFIG = join(settings.CONF_DIR, 'storage-aggregation.conf')
 STORAGE_LISTS_DIR = join(settings.CONF_DIR, 'lists')
 
+
 def getFilesystemPath(metric):
   return state.database.getFilesystemPath(metric)
 
@@ -35,7 +37,7 @@ class Schema:
     raise NotImplementedError()
 
   def matches(self, metric):
-    return bool( self.test(metric) )
+    return bool(self.test(metric))
 
 
 class DefaultSchema(Schema):
@@ -62,7 +64,7 @@ class PatternSchema(Schema):
 
 class Archive:
 
-  def __init__(self,secondsPerPoint,points):
+  def __init__(self, secondsPerPoint, points):
     self.secondsPerPoint = int(secondsPerPoint)
     self.points = int(points)
 
@@ -70,7 +72,7 @@ class Archive:
     return "Archive = (Seconds per point: %d, Datapoints to save: %d)" % (self.secondsPerPoint, self.points)
 
   def getTuple(self):
-    return (self.secondsPerPoint,self.points)
+    return (self.secondsPerPoint, self.points)
 
   @staticmethod
   def fromString(retentionDef):
@@ -84,11 +86,11 @@ def loadStorageSchemas():
   config.read(STORAGE_SCHEMAS_CONFIG)
 
   for section in config.sections():
-    options = dict( config.items(section) )
+    options = dict(config.items(section))
     pattern = options.get('pattern')
 
     retentions = options['retentions'].split(',')
-    archives = [ Archive.fromString(s) for s in retentions ]
+    archives = [Archive.fromString(s) for s in retentions]
 
     if pattern:
       mySchema = PatternSchema(section, pattern, archives)
@@ -102,7 +104,7 @@ def loadStorageSchemas():
       whisper.validateArchiveList(archiveList)
       schemaList.append(mySchema)
     except whisper.InvalidConfiguration, e:
-      log.msg("Invalid schemas found in %s: %s" % (section, e) )
+      log.msg("Invalid schemas found in %s: %s" % (section, e))
 
   schemaList.append(defaultSchema)
   return schemaList
@@ -119,7 +121,7 @@ def loadAggregationSchemas():
     log.msg("%s not found or wrong perms, ignoring." % STORAGE_AGGREGATION_CONFIG)
 
   for section in config.sections():
-    options = dict( config.items(section) )
+    options = dict(config.items(section))
     pattern = options.get('pattern')
 
     xFilesFactor = options.get('xfilesfactor')
@@ -148,6 +150,6 @@ def loadAggregationSchemas():
   schemaList.append(defaultAggregation)
   return schemaList
 
-defaultArchive = Archive(60, 60 * 24 * 7) #default retention for unclassified data (7 days of minutely data)
+defaultArchive = Archive(60, 60 * 24 * 7)  # default retention for unclassified data (7 days of minutely data)
 defaultSchema = DefaultSchema('default', [defaultArchive])
 defaultAggregation = DefaultSchema('default', (None, None))

--- a/lib/carbon/util.py
+++ b/lib/carbon/util.py
@@ -3,7 +3,7 @@ import os
 import pwd
 import __builtin__
 
-from os.path import abspath, basename, dirname, join
+from os.path import abspath, basename, dirname
 try:
   from cStringIO import StringIO
 except ImportError:
@@ -109,10 +109,9 @@ def parseDestinations(destination_strings):
     else:
       raise ValueError("Invalid destination string \"%s\"" % dest_string)
 
-    destinations.append( (server, int(port), instance) )
+    destinations.append((server, int(port), instance))
 
   return destinations
-
 
 
 # This whole song & dance is due to pickle being insecure
@@ -123,8 +122,8 @@ def parseDestinations(destination_strings):
 if USING_CPICKLE:
   class SafeUnpickler(object):
     PICKLE_SAFE = {
-      'copy_reg' : set(['_reconstructor']),
-      '__builtin__' : set(['object']),
+      'copy_reg': set(['_reconstructor']),
+      '__builtin__': set(['object']),
     }
 
     @classmethod
@@ -146,9 +145,10 @@ if USING_CPICKLE:
 else:
   class SafeUnpickler(pickle.Unpickler):
     PICKLE_SAFE = {
-      'copy_reg' : set(['_reconstructor']),
-      '__builtin__' : set(['object']),
+      'copy_reg': set(['_reconstructor']),
+      '__builtin__': set(['object']),
     }
+
     def find_class(self, module, name):
       if not module in self.PICKLE_SAFE:
         raise pickle.UnpicklingError('Attempting to unpickle unsafe module %s' % module)
@@ -157,11 +157,11 @@ else:
       if not name in self.PICKLE_SAFE[module]:
         raise pickle.UnpicklingError('Attempting to unpickle unsafe class %s' % name)
       return getattr(mod, name)
- 
+
     @classmethod
     def loads(cls, pickle_string):
       return cls(StringIO(pickle_string)).load()
- 
+
 
 def get_unpickler(insecure=False):
   if insecure:


### PR DESCRIPTION
I came across #315 - and wondered just how much really is out of sync.  As far as I can see, it looks like just three things remain.

- ``FORWARD_ALL`` config option not in master
- Whitespace/PEP8 fixes
- AMPQ related stuff.

This pulls in whitespace changes.