### PR TITLE
Fix documentation on random write strategy

### DIFF
--- a/conf/carbon.conf.example
+++ b/conf/carbon.conf.example
@@ -129,7 +129,7 @@ LOG_CACHE_QUEUE_SORTS = False
 # there are a large number of metrics which receive very frequent updates OR if
 # disk i/o is very slow.
 #
-# naive - Metrics will be flushed from the cache to disk in an unordered
+# random - Metrics will be flushed from the cache to disk in an unordered
 # fashion. This strategy may be desirable in situations where the storage for
 # whisper files is solid state, CPU resources are very limited or deference to
 # the OS's i/o scheduler is expected to compensate for the random write


### PR DESCRIPTION
The configuration option has always been ``random``, not ``naive``.