### PR TITLE
Implement NaiveStrategy class

### DIFF
--- a/lib/carbon/cache.py
+++ b/lib/carbon/cache.py
@@ -44,6 +44,23 @@ class DrainStrategy(object):
     raise NotImplemented
 
 
+class NaiveStrategy(DrainStrategy):
+  """Pop points in an unordered fashion."""
+  def __init__(self, cache):
+    super(NaiveStrategy, self).__init__(cache)
+
+    def _generate_queue():
+      while True:
+        metric_names = self.cache.keys()
+        while metric_names:
+          yield metric_names.pop()
+
+    self.queue = _generate_queue()
+
+  def choose_item(self):
+    return self.queue.next()
+
+
 class MaxStrategy(DrainStrategy):
   """Always pop the metric with the greatest number of points stored.
   This method leads to less variance in pointsPerUpdate but may mean
@@ -150,6 +167,8 @@ class _MetricCache(dict):
 
 # Initialize a singleton cache instance
 write_strategy = None
+if settings.CACHE_WRITE_STRATEGY == 'naive':
+  write_strategy = NaiveStrategy
 if settings.CACHE_WRITE_STRATEGY == 'max':
   write_strategy = MaxStrategy
 if settings.CACHE_WRITE_STRATEGY == 'sorted':


### PR DESCRIPTION
This is a hybrid between ``_MetricCache(None)`` and ``_MetricCache(SortedStrategy)``.

Like ``SortedStrategy``, it generates a queue to drain, however nothing special is done to sort the queue in any way.

When testing against the only available benchmark I could find for carbon (in 0.9.x branch), this made ``naive`` ever so slightly faster than the ``sorted`` strategy at least when draining in memory.  Haven't tested on any real SSDs or Disks yet, however.
