### PR TITLE
Deduplicate points before sending them to whisper.

### DIFF
--- a/lib/carbon/writer.py
+++ b/lib/carbon/writer.py
@@ -119,6 +119,10 @@ def writeCachedDataPoints():
         UPDATE_BUCKET.drain(1, blocking=True)
       try:
         t1 = time.time()
+        # If we have duplicated points, always pick the last. update_many()
+        # has no guaranted behavior for that, and in fact the current implementation
+        # will keep the first point in the list.
+        datapoints = dict(datapoints).items()
         state.database.write(metric, datapoints)
         updateTime = time.time() - t1
       except Exception:


### PR DESCRIPTION
This fix a common bug with aggregators that can re-send the same
value with the exact same timestamp multiple times (if
`MAX_AGGREGATION_INTERVAL > 1`). If `MAX_UPDATES_PER_SECOND` actively
rate-limit writes, then these points with the same timestamp are
likely to be written together.

The issue is that `update_many()` has no guaranteed behavior for that,
and in fact the current implementation will keep the first point in
the list. The following lines of code can demonstrate this behavior:
```
    filename = 'test.wsp'
    now = time.time()
    whisper.create(filename, [(1,20)])

    for points in ([(now, 1), (now, 2)], [(now, 2), (now, 1)]):
      whisper.update_many(filename, points)
      print 'input: ', points
      print 'result: ', whisper.fetch(filename, 0)
```
The output will be:
```
    input:  [(1450030881.415498, 1), (1450030881.415498, 2)]
    result:  ((1450030862, 1450030882, 1), [..., 1.0])
    input:  [(1450030881.415498, 2), (1450030881.415498, 1)]
    result:  ((1450030862, 1450030882, 1), [..., 2.0])
```
This isn't itself a bug in whisper since the function has no
guarantee that the order of the points will have any meaning.

With this patch, the last sent point will always take precedence,
which is already the current behavior if points are written in
separate `update_many()` calls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/graphite-project/carbon/499)
<!-- Reviewable:end -->
