### PR TITLE
More test coverage for carbon client

### DIFF
--- a/lib/carbon/tests/test_client.py
+++ b/lib/carbon/tests/test_client.py
@@ -1,19 +1,20 @@
-from nose.twistedtools import deferred, reactor
-
-from twisted.internet.task import deferLater
-from twisted.test.proto_helpers import StringTransport
-
 import carbon.client as carbon_client
-from carbon.client import CarbonClientFactory
+from carbon.client import CarbonClientFactory, CarbonClientProtocol, CarbonClientManager
 from carbon.routers import DatapointRouter
 from carbon.tests.util import TestSettings
 from carbon import instrumentation
 
-from pickle import loads as pickle_loads
-from struct import unpack, calcsize
-from unittest import TestCase
+from twisted.internet import reactor
+from twisted.internet.defer import Deferred
+from twisted.internet.base import DelayedCall
+from twisted.internet.task import deferLater
+from twisted.trial.unittest import TestCase
+from twisted.test.proto_helpers import StringTransport
 
 from mock import Mock, patch
+from pickle import loads as pickle_loads
+from struct import unpack, calcsize
+
 
 INT32_FORMAT = '!I'
 INT32_SIZE = calcsize(INT32_FORMAT)
@@ -43,12 +44,11 @@ class BroadcastRouter(DatapointRouter):
 class ConnectedCarbonClientProtocolTest(TestCase):
   def setUp(self):
     carbon_client.settings = TestSettings()  # reset to defaults
-    factory = CarbonClientFactory(('127.0.0.1', 0, 'a'))
-    self.protocol = factory.buildProtocol(('127.0.0.1', 0))
+    factory = CarbonClientFactory(('127.0.0.1', 2003, 'a'))
+    self.protocol = factory.buildProtocol(('127.0.0.1', 2003))
     self.transport = StringTransport()
     self.protocol.makeConnection(self.transport)
 
-  @deferred(timeout=1.0)
   def test_send_datapoint(self):
     def assert_sent():
       sent_data = self.transport.value()
@@ -58,3 +58,108 @@ class ConnectedCarbonClientProtocolTest(TestCase):
     datapoint = ('foo.bar', (1000000000, 1.0))
     self.protocol.sendDatapoint(*datapoint)
     return deferLater(reactor, 0.1, assert_sent)
+
+
+@patch('carbon.state.instrumentation', Mock(spec=instrumentation))
+class CarbonClientFactoryTest(TestCase):
+  def setUp(self):
+    self.protocol_mock = Mock(spec=CarbonClientProtocol)
+    self.protocol_patch = patch('carbon.client.CarbonClientProtocol', new=Mock(return_value=self.protocol_mock))
+    self.protocol_patch.start()
+    carbon_client.settings = TestSettings()
+    self.factory = CarbonClientFactory(('127.0.0.1', 2003, 'a'))
+    self.connected_factory = CarbonClientFactory(('127.0.0.1', 2003, 'a'))
+    self.connected_factory.buildProtocol(None)
+    self.connected_factory.started = True
+
+  def tearDown(self):
+    if self.factory.deferSendPending and self.factory.deferSendPending.active():
+      self.factory.deferSendPending.cancel()
+    self.protocol_patch.stop()
+
+  def test_schedule_send_schedules_call_to_send_queued(self):
+    self.factory.scheduleSend()
+    self.assertIsInstance(self.factory.deferSendPending, DelayedCall)
+    self.assertTrue(self.factory.deferSendPending.active())
+
+  def test_schedule_send_ignores_already_scheduled(self):
+    self.factory.scheduleSend()
+    expected_fire_time = self.factory.deferSendPending.getTime()
+    self.factory.scheduleSend()
+    self.assertTrue(expected_fire_time, self.factory.deferSendPending.getTime())
+
+  def test_send_queued_should_noop_if_not_connected(self):
+    self.factory.scheduleSend()
+    self.assertFalse(self.protocol_mock.sendQueued.called)
+
+  def test_send_queued_should_call_protocol_send_queued(self):
+    self.connected_factory.sendQueued()
+    self.protocol_mock.sendQueued.assert_called_once_with()
+
+
+@patch('carbon.state.instrumentation', Mock(spec=instrumentation))
+class CarbonClientManagerTest(TestCase):
+  timeout = 1.0
+  def setUp(self):
+    self.router_mock = Mock(spec=DatapointRouter)
+    self.factory_mock = Mock(spec=CarbonClientFactory)
+    self.factory_patch = patch('carbon.client.CarbonClientFactory', new=self.factory_mock)
+    self.factory_patch.start()
+    self.client_mgr = CarbonClientManager(self.router_mock)
+
+  def tearDown(self):
+    self.factory_patch.stop()
+
+  @patch('signal.signal', new=Mock())
+  def test_start_service_installs_sig_ignore(self, signal_mock):
+    from signal import SIGHUP, SIG_IGN
+
+    self.client_mgr.startService()
+    signal_mock.assert_called_once_with(SIGHUP, SIG_IGN)
+
+  def test_start_service_starts_factory_connect(self):
+    factory_mock = Mock(spec=CarbonClientFactory)
+    factory_mock.started = False
+    self.client_mgr.client_factories[('127.0.0.1', 2003, 'a')] = factory_mock
+    self.client_mgr.startService()
+    factory_mock.startConnecting.assert_called_once_with()
+
+  def test_stop_service_waits_for_clients_to_disconnect(self):
+    dest = ('127.0.0.1', 2003, 'a')
+    self.client_mgr.startService()
+    self.client_mgr.startClient(dest)
+
+    disconnect_deferred = Deferred()
+    reactor.callLater(0.1, disconnect_deferred.callback, 0)
+    self.factory_mock.return_value.disconnect.return_value = disconnect_deferred
+    return self.client_mgr.stopService()
+  test_stop_service_waits_for_clients_to_disconnect.skip = "stopService not returning a deferred!"
+
+  def test_start_client_instantiates_client_factory(self):
+    dest = ('127.0.0.1', 2003, 'a')
+    self.client_mgr.startClient(dest)
+    self.factory_mock.assert_called_once_with(dest)
+
+  def test_start_client_ignores_duplicate(self):
+    dest = ('127.0.0.1', 2003, 'a')
+    self.client_mgr.startClient(dest)
+    self.client_mgr.startClient(dest)
+    self.factory_mock.assert_called_once_with(dest)
+
+  def test_start_client_starts_factory_if_running(self):
+    dest = ('127.0.0.1', 2003, 'a')
+    self.client_mgr.startService()
+    self.client_mgr.startClient(dest)
+    self.factory_mock.return_value.startConnecting.assert_called_once_with()
+
+  def test_start_client_adds_destination_to_router(self):
+    dest = ('127.0.0.1', 2003, 'a')
+    self.client_mgr.startClient(dest)
+    self.router_mock.addDestination.assert_called_once_with(dest)
+
+  def test_stop_client_removes_destination_from_router(self):
+    dest = ('127.0.0.1', 2003, 'a')
+    self.client_mgr.startClient(dest)
+    self.client_mgr.stopClient(dest)
+    self.router_mock.removeDestination.assert_called_once_with(dest)
+


### PR DESCRIPTION
An afternoon's worth of unit tests for carbon.client

- New tests for CarbonClientFactory and CarbonClientManager
- Use Twisted's UnitTest rather than nose's twisted utils