### PR TITLE
Fix carbon client queue flush at shutdown

### DIFF
--- a/lib/carbon/client.py
+++ b/lib/carbon/client.py
@@ -345,7 +345,7 @@ class CarbonClientManager(Service):
 
   def stopService(self):
     Service.stopService(self)
-    self.stopAllClients()
+    return self.stopAllClients()
 
   def startClient(self, destination):
     if destination in self.client_factories:

--- a/lib/carbon/tests/test_client.py
+++ b/lib/carbon/tests/test_client.py
@@ -133,7 +133,6 @@ class CarbonClientManagerTest(TestCase):
     reactor.callLater(0.1, disconnect_deferred.callback, 0)
     self.factory_mock.return_value.disconnect.return_value = disconnect_deferred
     return self.client_mgr.stopService()
-  test_stop_service_waits_for_clients_to_disconnect.skip = "stopService not returning a deferred!"
 
   def test_start_client_instantiates_client_factory(self):
     dest = ('127.0.0.1', 2003, 'a')


### PR DESCRIPTION
Fixes #501 in carbon-relay and carbon-aggregator case - I think carbon-cache is already working (unverified)

I had thought carbon-relay flushed queues on exit, but on closer inspection (and with the new unit tests in #502) Twisted doesn't wait for clients to finish flushing and stopping because the deferred to wait on is never returned from CarbonClientManager's stopService. Simply returning the result of CarbonClientManager.stopAllClients fixes this behavior.