### PR TITLE
Improve consistent hash performance in single-node case

### DIFF
--- a/lib/carbon/hashing.py
+++ b/lib/carbon/hashing.py
@@ -42,6 +42,11 @@ class ConsistentHashRing:
 
   def get_nodes(self, key):
     assert self.ring
+    if len(self.nodes) == 1:
+      # short circuit in simple 1-node case
+      for node in self.nodes:
+        yield node
+        return
     nodes = set()
     position = self.compute_ring_position(key)
     search_entry = (position, None)


### PR DESCRIPTION
Carbon-relay and carbon-aggregator hash all incoming metrics to route via consistent hashing, even when there's only a single node which will receive 100% of them.

Instead, the hashing code should short circuit when only one node exists to save CPU. This is especially important with carbon-aggregator as it has only consistent-hashing mode available.

Before and after with a single-destination carbon-relay being fed 10,000 metrics/sec (1 datapointsPerSec)
![carbon_relay-simplified_hashing](https://cloud.githubusercontent.com/assets/317999/11862629/db58a55c-a452-11e5-8074-f9a514bed648.png)
