### PR TITLE
Re-order service startup and shutdown

### DIFF
--- a/lib/carbon/service.py
+++ b/lib/carbon/service.py
@@ -41,8 +41,6 @@ def createBaseService(config, settings):
     root_service = CarbonRootService()
     root_service.setName(settings.program)
 
-    setupReceivers(root_service, settings)
-
     if settings.USE_WHITELIST:
       from carbon.regexlist import WhiteList, BlackList
       WhiteList.read_from(settings.whitelist)
@@ -101,6 +99,7 @@ def createCacheService(config):
 
   root_service = createBaseService(config, settings)
   setupPipeline(['write'], root_service, settings)
+  setupReceivers(root_service, settings)
 
   return root_service
 
@@ -111,6 +110,7 @@ def createAggregatorService(config):
   settings.RELAY_METHOD = 'consistent-hashing'
   root_service = createBaseService(config, settings)
   setupPipeline(['rewrite:pre', 'aggregate', 'rewrite:post', 'relay'], root_service, settings)
+  setupReceivers(root_service, settings)
 
   return root_service
 
@@ -120,6 +120,8 @@ def createRelayService(config):
 
   root_service = createBaseService(config, settings)
   setupPipeline(['relay'], root_service, settings)
+  setupReceivers(root_service, settings)
+
   return root_service
 
 


### PR DESCRIPTION
Graphite was starting its services with the receivers (tcp, udp listening servers) before the writers (carbon-cache, relay). At shutdown, these were stopped in reverse order - writers, then receiver (see https://github.com/twisted/twisted/blob/trunk/twisted/application/service.py#L280-L292).

This has the potential to cause a small number of metrics to be received when there is nothing to write to them which is what appears to have happened in #506

