### PR TITLE
Remove remaining dependencies on whisper

### DIFF
--- a/lib/carbon/database.py
+++ b/lib/carbon/database.py
@@ -47,6 +47,10 @@ class TimeSeriesDatabase(object):
     "Return filesystem path for metric, defaults to None."
     pass
 
+  def validateArchiveList(self, archiveList):
+    "Validate that the database can handle the given archiveList."
+    pass
+
 
 try:
   import whisper
@@ -123,3 +127,9 @@ else:
     def getFilesystemPath(self, metric):
       metric_path = metric.replace('.', sep).lstrip(sep) + '.wsp'
       return join(self.data_dir, metric_path)
+
+    def validateArchiveList(self, archiveList):
+      try:
+        whisper.validateArchiveList(archiveList)
+      except whisper.InvalidConfiguration, e:
+        raise ValueError("%s" % e)

--- a/lib/carbon/database.py
+++ b/lib/carbon/database.py
@@ -23,6 +23,9 @@ class TimeSeriesDatabase(object):
   __metaclass__ = PluginRegistrar
   plugins = {}
 
+  "List of supported aggregation methods for the database."
+  aggregationMethods = []
+
   def write(self, metric, datapoints):
     "Persist datapoints in the database for metric."
     raise NotImplemented()
@@ -59,6 +62,7 @@ except ImportError:
 else:
   class WhisperDatabase(TimeSeriesDatabase):
     plugin_name = 'whisper'
+    aggregationMethods = whisper.aggregationMethods
 
     def __init__(self, settings):
       self.data_dir = settings.LOCAL_DATA_DIR

--- a/lib/carbon/storage.py
+++ b/lib/carbon/storage.py
@@ -28,10 +28,6 @@ STORAGE_AGGREGATION_CONFIG = join(settings.CONF_DIR, 'storage-aggregation.conf')
 STORAGE_LISTS_DIR = join(settings.CONF_DIR, 'lists')
 
 
-def getFilesystemPath(metric):
-  return state.database.getFilesystemPath(metric)
-
-
 class Schema:
   def test(self, metric):
     raise NotImplementedError()

--- a/lib/carbon/storage.py
+++ b/lib/carbon/storage.py
@@ -97,9 +97,9 @@ def loadStorageSchemas():
     archiveList = [a.getTuple() for a in archives]
 
     try:
-      whisper.validateArchiveList(archiveList)
+      state.database.validateArchiveList(archiveList)
       schemaList.append(mySchema)
-    except whisper.InvalidConfiguration, e:
+    except ValueError, e:
       log.msg("Invalid schemas found in %s: %s" % (section, e))
 
   schemaList.append(defaultSchema)

--- a/lib/carbon/storage.py
+++ b/lib/carbon/storage.py
@@ -14,7 +14,6 @@ limitations under the License."""
 
 import os
 import re
-import whisper
 
 from os.path import join, exists
 from carbon.conf import OrderedConfigParser, settings
@@ -128,7 +127,7 @@ def loadAggregationSchemas():
         xFilesFactor = float(xFilesFactor)
         assert 0 <= xFilesFactor <= 1
       if aggregationMethod is not None:
-        assert aggregationMethod in whisper.aggregationMethods
+        assert aggregationMethod in state.database.aggregationMethods
     except ValueError:
       log.msg("Invalid schemas found in %s." % section)
       continue

--- a/lib/carbon/storage.py
+++ b/lib/carbon/storage.py
@@ -96,7 +96,8 @@ def loadStorageSchemas():
     archiveList = [a.getTuple() for a in archives]
 
     try:
-      state.database.validateArchiveList(archiveList)
+      if state.database is not None:
+        state.database.validateArchiveList(archiveList)
       schemaList.append(mySchema)
     except ValueError, e:
       log.msg("Invalid schemas found in %s: %s" % (section, e))
@@ -127,7 +128,8 @@ def loadAggregationSchemas():
         xFilesFactor = float(xFilesFactor)
         assert 0 <= xFilesFactor <= 1
       if aggregationMethod is not None:
-        assert aggregationMethod in state.database.aggregationMethods
+        if state.database is not None:
+          assert aggregationMethod in state.database.aggregationMethods
     except ValueError:
       log.msg("Invalid schemas found in %s." % section)
       continue

--- a/lib/carbon/storage.py
+++ b/lib/carbon/storage.py
@@ -19,7 +19,7 @@ import whisper
 from os.path import join, exists
 from carbon.conf import OrderedConfigParser, settings
 from carbon.exceptions import CarbonConfigException
-from carbon.util import pickle
+from carbon.util import pickle, parseRetentionDef
 from carbon import log, state
 
 
@@ -72,7 +72,7 @@ class Archive:
 
   @staticmethod
   def fromString(retentionDef):
-    (secondsPerPoint, points) = whisper.parseRetentionDef(retentionDef)
+    (secondsPerPoint, points) = parseRetentionDef(retentionDef)
     return Archive(secondsPerPoint, points)
 
 

--- a/lib/carbon/tests/test_database.py
+++ b/lib/carbon/tests/test_database.py
@@ -1,0 +1,23 @@
+import os
+from unittest import TestCase
+from mock import patch
+
+from carbon.tests.util import TestSettings
+from carbon.database import WhisperDatabase
+
+
+class WhisperDatabaseTest(TestCase):
+
+    def setUp(self):
+        self._sep_patch = patch.object(os.path, 'sep', "/")
+        self._sep_patch.start()
+        settings = TestSettings()
+        settings['LOCAL_DATA_DIR'] = '/tmp/'
+        self.database = WhisperDatabase(settings)
+
+    def tearDown(self):
+        self._sep_patch.stop()
+
+    def test_getFilesystemPath(self):
+        result = self.database.getFilesystemPath('stats.example.counts')
+        self.assertEquals(result, '/tmp/stats/example/counts.wsp')

--- a/lib/carbon/tests/test_retentions.py
+++ b/lib/carbon/tests/test_retentions.py
@@ -1,0 +1,41 @@
+from unittest import TestCase
+from carbon.util import parseRetentionDef
+
+
+class TestParseRetentionDef(TestCase):
+    def test_valid_retentions(self):
+        retention_map = (
+            ('60:10', (60, 10)),
+            ('10:60', (10, 60)),
+            ('10s:10h', (10, 3600)),
+        )
+        for retention, expected in retention_map:
+            results = parseRetentionDef(retention)
+            self.assertEqual(results, expected)
+
+    def test_invalid_retentions(self):
+        retention_map = (
+            # From getUnitString
+            ('10x:10', ValueError("Invalid unit 'x'")),
+            ('60:10x', ValueError("Invalid unit 'x'")),
+
+            # From parseRetentionDef
+            ('10X:10', ValueError("Invalid precision specification '10X'")),
+            ('10:10$', ValueError("Invalid retention specification '10$'")),
+            ('60:10', (60, 10)),
+        )
+        for retention, expected_exc in retention_map:
+            try:
+                results = parseRetentionDef(retention)
+            except expected_exc.__class__ as exc:
+                self.assertEqual(
+                    str(expected_exc),
+                    str(exc),
+                )
+                self.assertEqual(
+                    expected_exc.__class__,
+                    exc.__class__,
+                )
+            else:
+                # When there isn't an exception raised
+                self.assertEqual(results, expected_exc)

--- a/lib/carbon/tests/test_storage.py
+++ b/lib/carbon/tests/test_storage.py
@@ -2,8 +2,6 @@ import os
 from unittest import TestCase
 from mock import patch
 
-from carbon.tests.util import TestSettings
-from carbon.database import WhisperDatabase
 
 # class NoConfigSchemaLoadingTest(TestCase):
 
@@ -85,23 +83,3 @@ class ExistingConfigSchemaLoadingTest(TestCase):
         schema_list = loadAggregationSchemas()
         last_schema = schema_list[-1]
         self.assertEquals(last_schema, defaultAggregation)
-
-
-class getFilesystemPathTest(TestCase):
-
-    def setUp(self):
-        self._sep_patch = patch.object(os.path, 'sep', "/")
-        self._sep_patch.start()
-        settings = TestSettings()
-        settings['LOCAL_DATA_DIR'] = '/tmp/'
-        self._database_patch = patch('carbon.state.database', new=WhisperDatabase(settings))
-        self._database_patch.start()
-
-    def tearDown(self):
-        self._database_patch.stop()
-        self._sep_patch.stop()
-
-    def test_getFilesystemPath(self):
-        from carbon.storage import getFilesystemPath
-        result = getFilesystemPath('stats.example.counts')
-        self.assertEquals(result, '/tmp/stats/example/counts.wsp')

--- a/lib/carbon/tests/test_storage.py
+++ b/lib/carbon/tests/test_storage.py
@@ -2,6 +2,9 @@ import os
 from unittest import TestCase
 from mock import patch
 
+from carbon.tests.util import TestSettings
+from carbon.database import WhisperDatabase
+
 
 # class NoConfigSchemaLoadingTest(TestCase):
 
@@ -33,13 +36,16 @@ class ExistingConfigSchemaLoadingTest(TestCase):
 
     def setUp(self):
         test_directory = os.path.dirname(os.path.realpath(__file__))
-        settings = {
-            'CONF_DIR': os.path.join(test_directory, 'data', 'conf-directory'),
-        }
-        self._settings_patch = patch.dict('carbon.conf.settings', settings)
+        settings = TestSettings()
+        settings['CONF_DIR'] = os.path.join(test_directory, 'data', 'conf-directory')
+        settings['LOCAL_DATA_DIR'] = ''
+        self._settings_patch = patch('carbon.conf.settings', settings)
         self._settings_patch.start()
+        self._database_patch = patch('carbon.state.database', new=WhisperDatabase(settings))
+        self._database_patch.start()
 
     def tearDown(self):
+        self._database_patch.stop()
         self._settings_patch.stop()
 
     def test_loadStorageSchemas_return_schemas(self):


### PR DESCRIPTION
As per #484

This does the following:
- Log the metric path instead of the filesystem path in ``writeCachedDataPoints``, because the storage database may not have an underlying filesystem.
- Move ``parseRetentionDef`` into carbon (yes, this is pretty much duplicated from whisper).
- Add ``aggregateMethods`` and ``validateArchiveList``abstractions, which are not found in ``megacarbon`` branch (megacarbon chooses not to care).

With this, the only place where whisper is imported is in database.py.