### PR TITLE
Fix KeyError crash when MetricCache becomes too full

### DIFF
--- a/lib/carbon/cache.py
+++ b/lib/carbon/cache.py
@@ -123,7 +123,7 @@ class _MetricCache(dict):
 
   def _check_available_space(self):
     if state.cacheTooFull and self.size < settings.CACHE_SIZE_LOW_WATERMARK:
-      log.msg("cache size below watermark")
+      log.msg("MetricCache below watermark: self.size=%d" % self.size)
       events.cacheSpaceAvailable()
 
   def drain_metric(self):

--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -247,6 +247,8 @@ class CarbonCacheOptions(usage.Options):
         database_class = TimeSeriesDatabase.plugins[database]
         state.database = database_class(settings)
 
+        settings.CACHE_SIZE_LOW_WATERMARK = settings.MAX_CACHE_SIZE * 0.95
+
         if not "action" in self:
             self["action"] = "start"
         self.handleAction()

--- a/lib/carbon/tests/test_cache.py
+++ b/lib/carbon/tests/test_cache.py
@@ -76,6 +76,13 @@ class MetricCacheTest(TestCase):
       self.metric_cache.pop('foo')
       self.assertEqual(1, check_space_mock.call_count)
 
+  def test_pop_triggers_space_event(self):
+    with patch('carbon.state.cacheTooFull', new=Mock(return_value=True)):
+      with patch('carbon.cache.events') as events_mock:
+        self.metric_cache.store('foo', (123456, 1.0))
+        self.metric_cache.pop('foo')
+        events_mock.cacheSpaceAvailable.assert_called_with()
+
   def test_pop_returns_sorted_timestamps(self):
     self.metric_cache.store('foo', (123457, 2.0))
     self.metric_cache.store('foo', (123458, 3.0))

--- a/lib/carbon/writer.py
+++ b/lib/carbon/writer.py
@@ -34,7 +34,6 @@ except ImportError:
 
 SCHEMAS = loadStorageSchemas()
 AGGREGATION_SCHEMAS = loadAggregationSchemas()
-CACHE_SIZE_LOW_WATERMARK = settings.MAX_CACHE_SIZE * 0.95
 
 
 # Inititalize token buckets so that we can enforce rate limits on creates and
@@ -57,9 +56,6 @@ def optimalWriteOrder():
   rate limit on new metrics"""
   while MetricCache:
     (metric, datapoints) = MetricCache.drain_metric()
-    if state.cacheTooFull and MetricCache.size < CACHE_SIZE_LOW_WATERMARK:
-      events.cacheSpaceAvailable()
-
     dbFilePath = getFilesystemPath(metric)
     dbFileExists = state.database.exists(metric)
 


### PR DESCRIPTION
Carbon caches crash when MetricCache becomes too full.

```
[console] MetricCache is full: self.size=4000000
message repeated 13 times: [ [console] MetricCache is full: self.size=4000000]
[console] Unhandled Error
[console] #011Traceback (most recent call last):
[console] #011  File "/srv/graphite/site-packages/twisted/python/threadpool.py", line 246, in inContext
[console] #011    result = inContext.theWork()
[console] #011  File "/srv/graphite/site-packages/twisted/python/threadpool.py", line 262, in <lambda>
[console] #011    inContext.theWork = lambda: context.call(ctx, func, *args, **kw)
[console] #011  File "/srv/graphite/site-packages/twisted/python/context.py", line 118, in callWithContext
[console] #011    return self.currentContext().callWithContext(ctx, func, *args, **kw)
[console] #011  File "/srv/graphite/site-packages/twisted/python/context.py", line 81, in callWithContext
[console] #011    return func(*args,**kw)
[console] #011--- <exception caught here> ---
[console] #011  File "/srv/graphite/site-packages/carbon/writer.py", line 141, in writeForever
[console] #011    writeCachedDataPoints()
[console] #011  File "/srv/graphite/site-packages/carbon/writer.py", line 85, in writeCachedDataPoints
[console] #011    for (metric, datapoints, dbFileExists) in optimalWriteOrder():
[console] #011  File "/srv/graphite/site-packages/carbon/writer.py", line 58, in optimalWriteOrder
[console] #011    (metric, datapoints) = MetricCache.drain_metric()
[console] #011  File "/srv/graphite/site-packages/carbon/cache.py", line 139, in drain_metric
[console] #011    return (metric, self.pop(metric))
[console] #011  File "/srv/graphite/site-packages/carbon/cache.py", line 148, in pop
[console] #011    self._check_available_space()
[console] #011  File "/srv/graphite/site-packages/carbon/cache.py", line 125, in _check_available_space
[console] #011    if state.cacheTooFull and self.size < settings.CACHE_SIZE_LOW_WATERMARK:
[console] #011exceptions.KeyError: 'CACHE_SIZE_LOW_WATERMARK'
```

Moving ``CACHE_SIZE_LOW_WATERMARK`` to ``settings``, and removing the test from ``carbon.writer`` so that the check isn't done twice.