### PR TITLE
Synchronize calls to MetricCache.drain_metric from writer thread

### DIFF
--- a/lib/carbon/service.py
+++ b/lib/carbon/service.py
@@ -20,12 +20,10 @@ from twisted.internet.protocol import ServerFactory
 from twisted.python.components import Componentized
 from twisted.python.log import ILogObserver
 # Attaching modules to the global state module simplifies import order hassles
-from carbon import state, events, instrumentation, util
+from carbon import state, util
 from carbon.exceptions import CarbonConfigException
 from carbon.log import carbonLogObserver
 from carbon.pipeline import Processor, run_pipeline
-state.events = events
-state.instrumentation = instrumentation
 
 
 class CarbonReceiverFactory(ServerFactory):
@@ -49,6 +47,9 @@ class CarbonRootService(MultiService):
 
 
 def createBaseService(config, settings):
+    from carbon import events, instrumentation
+    state.events = events
+    state.instrumentation = instrumentation
     root_service = CarbonRootService()
     root_service.setName(settings.program)
 
@@ -68,6 +69,7 @@ def createBaseService(config, settings):
 
 
 def setupPipeline(pipeline, root_service, settings):
+  from carbon import events
   state.pipeline_processors = []
   for processor in pipeline:
     args = []

--- a/lib/carbon/tests/test_aggregator_buffers.py
+++ b/lib/carbon/tests/test_aggregator_buffers.py
@@ -9,6 +9,11 @@ from carbon.tests.util import TestSettings
 
 
 class AggregationBufferManagerTest(TestCase):
+  def setUp(self):
+    from carbon import state, instrumentation, events
+    state.instrumentation = instrumentation
+    state.events = events
+
   def tearDown(self):
     BufferManager.clear()
 


### PR DESCRIPTION
The writer thread drains from the cache in a separate thread from the reactor. This sometimes leads to weird race conditions (e.g. negative cache size metrics). Instead, run the cache drain on the main reactor
thread (the place where the cache is written to).

This keeps the rest of the draining logic (cache sorting, etc) in the writer thread so as not to block the event loop.

I've done some basic performance testing on this, the expectation being that there shouldn't be much difference. The comparisons I did show no difference in throughput but CPU seemed to be a little more consistent (same moving avg, smaller range).

I'd love if someone could canary this in production and report back