### PR TITLE
Change MetricLineReceiver delimiter to tab

### DIFF
--- a/lib/carbon/protocols.py
+++ b/lib/carbon/protocols.py
@@ -72,7 +72,7 @@ class MetricReceiver(TimeoutMixin):
 
 
 class MetricLineReceiver(MetricReceiver, LineOnlyReceiver):
-  delimiter = '\n'
+  delimiter = '\t'
 
   def lineReceived(self, line):
     try:


### PR DESCRIPTION
This should resolve common errors with the newline character. 
For example, in carbon console.log:
```
[listener] invalid line () received from client <HOST>:<PORT>, ignoring
```