### PR TITLE
Check for rename from external log rotation

### DIFF
--- a/lib/carbon/log.py
+++ b/lib/carbon/log.py
@@ -45,6 +45,12 @@ class CarbonLogFile(DailyLogFile):
     if not self.enableRotation:
       if not os.path.exists(self.path):
         self.reopen()
+      else:
+        path_stat = os.stat(self.path)
+        fd_stat = os.fstat(self._file.fileno())
+        if not (path_stat.st_ino == fd_stat.st_ino 
+            and path_stat.st_dev == fd_stat.st_dev):
+          self.reopen()
     DailyLogFile.write(self, data)
 
   # Backport from twisted >= 10


### PR DESCRIPTION
The log rotation support checks if a log file has disappeared, but doesn't detect log files that have moved if the log file path has been recreated. This adds a check to see if the inode of the currently open log file matches the inode of the file path, and reopens the log file if it does not match.