### PR TITLE
Don't stomp on config vaules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ else:
         pass
     if not cf.has_option('install', 'prefix'):
         cf.set('install', 'prefix', '/opt/graphite')
-    if not cf.has_options('install', 'install-lib'):
+    if not cf.has_option('install', 'install-lib'):
         cf.set('install', 'install-lib', '%(prefix)s/lib')
 
 with open('setup.cfg', 'wb') as f:

--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,10 @@ else:
         cf.add_section('install')
     except ConfigParser.DuplicateSectionError:
         pass
-    cf.set('install', 'prefix', '/opt/graphite')
-    cf.set('install', 'install-lib', '%(prefix)s/lib')
+    if not cf.has_option('install', 'prefix'):
+        cf.set('install', 'prefix', '/opt/graphite')
+    if not cf.has_options('install', 'install-lib'):
+        cf.set('install', 'install-lib', '%(prefix)s/lib')
 
 with open('setup.cfg', 'wb') as f:
     cf.write(f)


### PR DESCRIPTION
With this change, adding a prefix or install-lib path in setup.cfg won't get overwritten.