### PR TITLE
Added error msg for case where pidfile is not an int 

### DIFF
--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -329,6 +329,9 @@ class CarbonCacheOptions(usage.Options):
             try:
                 pid = int(pf.read().strip())
                 pf.close()
+            except ValueError:
+                print "Failed to parse pid from pidfile %s" % pidfile
+                raise SystemExit(1)
             except IOError:
                 print "Could not read pidfile %s" % pidfile
                 raise SystemExit(1)
@@ -351,6 +354,9 @@ class CarbonCacheOptions(usage.Options):
             try:
                 pid = int(pf.read().strip())
                 pf.close()
+            except ValueError:
+                print "Failed to parse pid from pidfile %s" % pidfile
+                raise SystemExit(1)
             except IOError:
                 print "Failed to read pid from %s" % pidfile
                 raise SystemExit(1)
@@ -369,6 +375,9 @@ class CarbonCacheOptions(usage.Options):
                 try:
                     pid = int(pf.read().strip())
                     pf.close()
+                except ValueError:
+                    print "Failed to parse pid from pidfile %s" % pidfile
+                    SystemExit(1)
                 except IOError:
                     print "Could not read pidfile %s" % pidfile
                     raise SystemExit(1)


### PR DESCRIPTION
If your disk happens to be full when "carbon-cache.py -start" is run it will successfully create an empty pidfile.  Subsequent commands all fail with an ugly error message like:

```
# service carbon-cache start
Starting carbon-cache:a...
Traceback (most recent call last):
  File "bin/carbon-cache.py", line 32, in <module>
    run_twistd_plugin(__file__)
  File "/opt/graphite/lib/carbon/util.py", line 94, in run_twistd_plugin
    config.parseOptions(twistd_options)
  File "/usr/lib64/python2.6/site-packages/twisted/application/app.py", line 669, in parseOptions
    usage.Options.parseOptions(self, options)
  File "/usr/lib64/python2.6/site-packages/twisted/python/usage.py", line 231, in parseOptions
    self.subOptions.parseOptions(rest)
  File "/usr/lib64/python2.6/site-packages/twisted/python/usage.py", line 241, in parseOptions
    self.postOptions()
  File "/opt/graphite/lib/carbon/conf.py", line 256, in postOptions
    self.handleAction()
  File "/opt/graphite/lib/carbon/conf.py", line 348, in handleAction
    pid = int(pf.read().strip())
ValueError: invalid literal for int() with base 10: ''
                                                           [FAILED]
```

With this fix if there is a ValueError (i.e. pid in pidfile can't be made into an int) a more helpful error will be displayed:
```
/opt/graphite/bin/carbon-cache.py status
Failed to parse pid from pidfile /opt/graphite/storage/carbon-cache-a.pid
```

Especially for a junior user the error helps them resolve faster.