### PR TITLE
Log rules file for aggregator parsing failure

### DIFF
--- a/lib/carbon/aggregator/rules.py
+++ b/lib/carbon/aggregator/rules.py
@@ -60,7 +60,7 @@ class RuleManager:
       return AggregationRule(input_pattern, output_pattern, method, frequency)
 
     except ValueError:
-      log.err("Failed to parse line: %s" % line)
+      log.err("Failed to parse rule in %s, line: %s" % (self.rules_file, line))
       raise
 
 


### PR DESCRIPTION
When failing to parse an aggregator rule, make sure to log the offending rules file as well.

refs #424 