### PR TITLE
Remove whisper imports from carbon (partial revert of #576)

### DIFF
--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -21,7 +21,6 @@ from os.path import join, dirname, normpath, exists, isdir
 from optparse import OptionParser
 from ConfigParser import ConfigParser
 
-import whisper
 from carbon import log, state
 from carbon.database import TimeSeriesDatabase
 from carbon.exceptions import CarbonConfigException
@@ -241,23 +240,6 @@ class CarbonCacheOptions(usage.Options):
         if not exists(storage_schemas):
             print "Error: missing required config %s" % storage_schemas
             sys.exit(1)
-
-        if settings.WHISPER_AUTOFLUSH:
-            log.msg("Enabling Whisper autoflush")
-            whisper.AUTOFLUSH = True
-
-        if settings.WHISPER_FALLOCATE_CREATE:
-            if whisper.CAN_FALLOCATE:
-                log.msg("Enabling Whisper fallocate support")
-            else:
-                log.err("WHISPER_FALLOCATE_CREATE is enabled but linking failed.")
-
-        if settings.WHISPER_LOCK_WRITES:
-            if whisper.CAN_LOCK:
-                log.msg("Enabling Whisper file locking")
-                whisper.LOCK = True
-            else:
-                log.err("WHISPER_LOCK_WRITES is enabled but import of fcntl module failed.")
 
         if settings.CACHE_WRITE_STRATEGY not in ('sorted', 'max', 'naive'):
             log.err("%s is not a valid value for CACHE_WRITE_STRATEGY, defaulting to %s" %


### PR DESCRIPTION
FYI @obfuscurity.  Partial revert of #576.

The whisper is config handling is found here https://github.com/graphite-project/carbon/blob/a8435b0e68ddfd8181113f18cb44c9c1adcce914/lib/carbon/database.py#L67-L96

Let's see how long until another whisper import creeps back into carbon (other than in carbon.database :-)