### PR TITLE
instrumentation: also record 'destinations.*' stats for aggregators

### DIFF
--- a/lib/carbon/instrumentation.py
+++ b/lib/carbon/instrumentation.py
@@ -129,6 +129,9 @@ def recordMetrics():
   # relay metrics
   else:
     record = relay_record
+
+  # shared relay stats for relays & aggregators
+  if settings.program in ['carbon-aggregator', 'carbon-relay']:
     prefix = 'destinations.'
     relay_stats =  [(k,v) for (k,v) in myStats.items() if k.startswith(prefix)]
     for stat_name, stat_value in relay_stats:


### PR DESCRIPTION
Aggregators are also relaying points, this enable 'destinations.*'
stats for aggregators which are critical to debug queue related issues.