### PR TITLE
Add support for IPv6 addresses enclosed in square brackets in the destination parser.

### DIFF
--- a/lib/carbon/tests/test_util.py
+++ b/lib/carbon/tests/test_util.py
@@ -1,0 +1,95 @@
+from unittest import TestCase
+
+from carbon.util import parseDestinations
+
+
+# Destinations have the form:
+# <host> ::= <string without colons> | "[" <string> "]"
+# <port> ::= <number>
+# <instance> ::= <string>
+# <destination> ::= <host> ":" <port> | <host> ":" <port> ":" <instance>
+
+class ParseDestinationsTest(TestCase):
+    def test_valid_dest_unbracketed(self):
+        # Tests valid destinations in the unbracketed form of <host>.
+        dests = [
+            "127.0.0.1:1234:alpha",         # Full IPv4 address
+            "127.1:1234:beta",              # 'Short' IPv4 address
+            "localhost:987:epsilon",        # Relative domain name
+            "foo.bar.baz.uk.:890:sigma"     # Absolute domain name
+        ]
+
+        expected = [
+            ("127.0.0.1", 1234, "alpha"),
+            ("127.1", 1234, "beta"),
+            ("localhost", 987, "epsilon"),
+            ("foo.bar.baz.uk.", 890, "sigma")
+        ]
+
+        actual = parseDestinations(dests)
+        self.assertEquals(len(expected), len(actual))
+
+        for exp, act in zip(expected, actual):
+            self.assertEquals(exp, act)
+
+    def test_valid_dest_bracketed(self):
+        # Tests valid destinations in the bracketed form of <host>.
+        dests = [
+            "[fe80:dead:beef:cafe:0007:0007:0007:0001]:123:gamma",  # Full IPv6 address
+            "[fe80:1234::7]:456:theta",                             # Compact IPv6 address
+            "[::]:1:o",                                             # Very compact IPv6 address
+            "[ffff::127.0.0.1]:789:omicron"                         # IPv6 mapped IPv4 address
+        ]
+
+        expected = [
+            ("fe80:dead:beef:cafe:0007:0007:0007:0001", 123, "gamma"),
+            ("fe80:1234::7", 456, "theta"),
+            ("::", 1, "o"),
+            ("ffff::127.0.0.1", 789, "omicron"),
+        ]
+
+        actual = parseDestinations(dests)
+        self.assertEquals(len(expected), len(actual))
+
+        for exp, act in zip(expected, actual):
+            self.assertEquals(exp, act)
+
+    def test_valid_dest_without_instance(self):
+        # Tests destinations without instance specified.
+        dests = [
+            "1.2.3.4:5678",
+            "[::1]:2",
+            "stats.example.co.uk:8125",
+            "[127.0.0.1]:78",               # Odd use of the bracket feature, but why not?
+            "[why.not.this.com]:89",
+        ]
+
+        expected = [
+            ("1.2.3.4", 5678, None),
+            ("::1", 2, None),
+            ("stats.example.co.uk", 8125, None),
+            ("127.0.0.1", 78, None),
+            ("why.not.this.com", 89, None)
+        ]
+
+        actual = parseDestinations(dests)
+        self.assertEquals(len(expected), len(actual))
+
+        for exp, act in zip(expected, actual):
+            self.assertEquals(exp, act)
+
+    def test_wrong_dest(self):
+        # Some cases of invalid input, e.g. invalid/missing port.
+        dests = [
+            "1.2.3.4",                      # No port
+            "1.2.3.4:huh",                  # Invalid port (must be int)
+            "[fe80::3285:a9ff:fe91:e287]",  # No port
+            "[ffff::1.2.3.4]:notaport"      # Invalid port
+        ]
+
+        for dest in dests:
+            try:
+                parseDestinations([dest])
+            except ValueError:
+                continue
+            raise AssertionError("Invalid input was accepted.")

--- a/lib/carbon/util.py
+++ b/lib/carbon/util.py
@@ -96,30 +96,29 @@ def run_twistd_plugin(filename):
     runApp(config)
 
 
-def parseDestinations(destination_strings):
-  destinations = []
-
-  for dest_string in destination_strings:
+def parseDestination(dest_string):
     s = dest_string.strip()
     bidx = s.rfind(']:')    # find closing bracket and following colon.
     cidx = s.find(':')
     if s.startswith('[') and bidx is not None:
-      server = s[1:bidx]
-      port = s[bidx + 2:]
+        server = s[1:bidx]
+        port = s[bidx + 2:]
     elif cidx is not None:
-      server = s[:cidx]
-      port = s[cidx + 1:]
+        server = s[:cidx]
+        port = s[cidx + 1:]
     else:
-      raise ValueError("Invalid destination string \"%s\"" % dest_string)
+        raise ValueError("Invalid destination string \"%s\"" % dest_string)
 
     if ':' in port:
-      port, _, instance = port.partition(':')
+        port, _, instance = port.partition(':')
     else:
-      instance = None
+        instance = None
 
-    destinations.append((server, int(port), instance))
+    return server, int(port), instance
 
-  return destinations
+
+def parseDestinations(destination_strings):
+    return [parseDestination(dest_string) for dest_string in destination_strings]
 
 
 # Yes this is duplicated in whisper. Yes, duplication is bad.

--- a/lib/carbon/util.py
+++ b/lib/carbon/util.py
@@ -101,9 +101,9 @@ def parseDestinations(destination_strings):
 
   for dest_string in destination_strings:
     s = dest_string.strip()
-    bidx = s.rfind("]:")    # find closing braket and following colon.
-    cidx = s.find(":")
-    if s.startswith("[") and bidx is not None:
+    bidx = s.rfind(']:')    # find closing bracket and following colon.
+    cidx = s.find(':')
+    if s.startswith('[') and bidx is not None:
       server = s[1:bidx]
       port = s[bidx + 2:]
     elif cidx is not None:
@@ -112,8 +112,8 @@ def parseDestinations(destination_strings):
     else:
       raise ValueError("Invalid destination string \"%s\"" % dest_string)
 
-    if ":" in port:
-      port, _, instance = port.partition(":")
+    if ':' in port:
+      port, _, instance = port.partition(':')
     else:
       instance = None
 

--- a/lib/carbon/util.py
+++ b/lib/carbon/util.py
@@ -100,14 +100,22 @@ def parseDestinations(destination_strings):
   destinations = []
 
   for dest_string in destination_strings:
-    parts = dest_string.strip().split(':')
-    if len(parts) == 2:
-      server, port = parts
-      instance = None
-    elif len(parts) == 3:
-      server, port, instance = parts
+    s = dest_string.strip()
+    bidx = s.rfind("]:")    # find closing braket and following colon.
+    cidx = s.find(":")
+    if s.startswith("[") and bidx is not None:
+      server = s[1:bidx]
+      port = s[bidx + 2:]
+    elif cidx is not None:
+      server = s[:cidx]
+      port = s[cidx + 1:]
     else:
       raise ValueError("Invalid destination string \"%s\"" % dest_string)
+
+    if ":" in port:
+      port, _, instance = port.partition(":")
+    else:
+      instance = None
 
     destinations.append((server, int(port), instance))
 


### PR DESCRIPTION
This should (partially) address issue #418.
