### PR TITLE
Fix CACHE_WRITE_STRATEGY and add TimeSortedStrategy

### DIFF
--- a/conf/carbon.conf.example
+++ b/conf/carbon.conf.example
@@ -146,6 +146,12 @@ LOG_CACHE_QUEUE_SORTS = False
 # moment of the list's creation. Metrics will then be flushed from the cache to
 # disk in that order.
 #
+# timesorted - All metrics in the list will be looked at and sorted according
+# to the timestamp of there datapoints. The metric that were the least recently
+# written will be written first. This is an hybrid strategy between max and
+# sorted which is particularly adapted to sets of metrics with non-uniform
+# resolutions.
+#
 # max - The writer thread will always pop and flush the metric from cache
 # that has the most datapoints. This will give a strong flush preference to
 # frequently updated metrics and will also reduce random file-io. Infrequently

--- a/lib/carbon/cache.py
+++ b/lib/carbon/cache.py
@@ -98,6 +98,7 @@ class SortedStrategy(DrainStrategy):
           log.msg("Sorted %d cache queues in %.6f seconds" % (len(metric_counts), time.time() - t))
         while metric_counts:
           yield itemgetter(0)(metric_counts.pop())
+        log.msg("Queue consumed in %.6f seconds" % (time.time() - t))
 
     self.queue = _generate_queue()
 
@@ -120,6 +121,7 @@ class TimeSortedStrategy(DrainStrategy):
           log.msg("Sorted %d cache queues in %.6f seconds" % (len(metric_lw), time.time() - t))
         while metric_lw:
           yield itemgetter(0)(metric_lw.pop())
+        log.msg("Queue consumed in %.6f seconds" % (time.time() - t))
 
     self.queue = _generate_queue()
 

--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -246,7 +246,7 @@ class CarbonCacheOptions(usage.Options):
             print "Error: missing required config %s" % storage_schemas
             sys.exit(1)
 
-        if settings.CACHE_WRITE_STRATEGY not in ('sorted', 'max', 'naive'):
+        if settings.CACHE_WRITE_STRATEGY not in ('timesorted', 'sorted', 'max', 'naive'):
             log.err("%s is not a valid value for CACHE_WRITE_STRATEGY, defaulting to %s" %
                     (settings.CACHE_WRITE_STRATEGY, defaults['CACHE_WRITE_STRATEGY']))
         else:

--- a/lib/carbon/instrumentation.py
+++ b/lib/carbon/instrumentation.py
@@ -92,8 +92,8 @@ def recordMetrics():
 
     # Calculate cache-data-structure-derived metrics prior to storing anything
     # in the cache itself -- which would otherwise affect said metrics.
-    cache_size = cache.MetricCache.size
-    cache_queues = len(cache.MetricCache)
+    cache_size = cache.MetricCache().size
+    cache_queues = len(cache.MetricCache())
     record('cache.size', cache_size)
     record('cache.queues', cache_queues)
 
@@ -167,7 +167,7 @@ def cache_record(metric, value):
     else:
       fullMetric = '%s.agents.%s-%s.%s' % (prefix, HOSTNAME, settings.instance, metric)
     datapoint = (time.time(), value)
-    cache.MetricCache.store(fullMetric, datapoint)
+    cache.MetricCache().store(fullMetric, datapoint)
 
 
 def relay_record(metric, value):

--- a/lib/carbon/tests/test_cache.py
+++ b/lib/carbon/tests/test_cache.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from mock import Mock, PropertyMock, patch
-from carbon.cache import _MetricCache, DrainStrategy, MaxStrategy, RandomStrategy, SortedStrategy
+from carbon.cache import MetricCache, _MetricCache, DrainStrategy, MaxStrategy, RandomStrategy, SortedStrategy, TimeSortedStrategy
 
 
 class MetricCacheTest(TestCase):
@@ -16,6 +16,16 @@ class MetricCacheTest(TestCase):
 
   def tearDown(self):
     self._settings_patch.stop()
+
+  def test_constructor(self):
+    settings = {
+      'CACHE_WRITE_STRATEGY': 'max',
+    }
+    settings_patch = patch.dict('carbon.conf.settings', settings)
+    settings_patch.start()
+    cache = MetricCache()
+    self.assertNotEqual(cache, None)
+    self.assertTrue(isinstance(cache.strategy, MaxStrategy))
 
   def test_cache_is_a_dict(self):
     self.assertTrue(issubclass(_MetricCache, dict))
@@ -223,6 +233,30 @@ class DrainStrategyTest(TestCase):
     self.assertEqual('foo', sorted_strategy.choose_item())
     self.assertEqual('bar', sorted_strategy.choose_item())
     self.assertEqual('baz', sorted_strategy.choose_item())
+
+  def test_time_sorted_strategy(self):
+    self.metric_cache.store('foo', (123456, 1.0))
+    self.metric_cache.store('foo', (123457, 2.0))
+    self.metric_cache.store('foo', (123458, 3.0))
+    self.metric_cache.store('bar', (123459, 4.0))
+    self.metric_cache.store('bar', (123460, 5.0))
+    self.metric_cache.store('baz', (123461, 6.0))
+
+    time_sorted_strategy = TimeSortedStrategy(self.metric_cache)
+    # In order: foo, bar, baz
+    self.assertEqual('foo', time_sorted_strategy.choose_item())
+
+    # 'baz' gets older points.
+    self.metric_cache.store('baz', (123450, 6.0))
+    self.metric_cache.store('baz', (123451, 6.0))
+    # But 'bar' is popped anyway, because sort has already happened
+    self.assertEqual('bar', time_sorted_strategy.choose_item())
+    self.assertEqual('baz', time_sorted_strategy.choose_item())
+
+    # Sort happens again
+    self.assertEqual('baz', time_sorted_strategy.choose_item())
+    self.assertEqual('foo', time_sorted_strategy.choose_item())
+    self.assertEqual('bar', time_sorted_strategy.choose_item())
 
 
 class RandomStrategyTest(TestCase):

--- a/lib/carbon/writer.py
+++ b/lib/carbon/writer.py
@@ -53,8 +53,9 @@ if settings.MAX_UPDATES_PER_SECOND != float('inf'):
 def optimalWriteOrder():
   """Generates metrics with the most cached values first and applies a soft
   rate limit on new metrics"""
-  while MetricCache:
-    (metric, datapoints) = MetricCache.drain_metric()
+  cache = MetricCache()
+  while cache:
+    (metric, datapoints) = cache.drain_metric()
     dbFileExists = state.database.exists(metric)
 
     if not dbFileExists and CREATE_BUCKET:
@@ -75,7 +76,8 @@ def optimalWriteOrder():
 def writeCachedDataPoints():
   "Write datapoints until the MetricCache is completely empty"
 
-  while MetricCache:
+  cache = MetricCache()
+  while cache:
     dataWritten = False
 
     for (metric, datapoints, dbFileExists) in optimalWriteOrder():


### PR DESCRIPTION
Due to a dependency hell the cache_write_strategy was always being
set to 'sorted'. Instantiate MetricCache lazilly to fix that.

Also add a new TimeSortedStrategy that will try to minize the ingestion
time.