### PR TITLE
Fix carbon line client protocol so it can send correct data

### DIFF
--- a/lib/carbon/client.py
+++ b/lib/carbon/client.py
@@ -358,7 +358,7 @@ class CarbonLineClientProtocol(CarbonClientProtocol, LineOnlyReceiver):
 
   def _sendDatapointsNow(self, datapoints):
     for metric, datapoint in datapoints:
-        self.sendLine("%s %s %d" % (metric, datapoint[0], datapoint[1]))
+        self.sendLine("%s %s %d" % (metric, datapoint[1], datapoint[0]))
 
 
 class CarbonLineClientFactory(CarbonClientFactory):

--- a/lib/carbon/tests/test_client.py
+++ b/lib/carbon/tests/test_client.py
@@ -1,5 +1,5 @@
 import carbon.client as carbon_client
-from carbon.client import CarbonPickleClientFactory, CarbonPickleClientProtocol, CarbonClientManager
+from carbon.client import CarbonPickleClientFactory, CarbonPickleClientProtocol, CarbonLineClientProtocol, CarbonClientManager
 from carbon.routers import DatapointRouter
 from carbon.tests.util import TestSettings
 from carbon import instrumentation
@@ -59,6 +59,19 @@ class ConnectedCarbonClientProtocolTest(TestCase):
     datapoint = ('foo.bar', (1000000000, 1.0))
     self.protocol.sendDatapoint(*datapoint)
     return deferLater(reactor, 0.1, assert_sent)
+
+
+class CarbonLineClientProtocolTest(TestCase):
+  def setUp(self):
+    self.protocol = CarbonLineClientProtocol()
+    self.protocol.sendLine = Mock()
+
+  def test_send_datapoints_now(self):
+    datapoint = ('foo.bar', (1000000000, 1.0))
+    expected_line_to_send = "foo.bar 1.0 1000000000"
+
+    self.protocol._sendDatapointsNow([datapoint])
+    self.protocol.sendLine.assert_called_once_with(expected_line_to_send)
 
 
 @patch('carbon.state.instrumentation', Mock(spec=instrumentation))


### PR DESCRIPTION
Currently when `DESTINATION_PROTOCOL` is set to `line` for carbon-relay.
It sends incorrect data to the destination. The order of metric value
and timestamp are changed from the source, for example, it turns
"test.mytest 1 1490397060" into "test.mytest 1490397060 1".

`CarbonLineClientProtocol` was introduced in a previous pull request #601
to support pluggable client protocols along with a number of other
changes. The incorrect order takes place in its method
`_sendDatapointsNow()`.

This fix will correct the order of segments, so metrics path, metric
value and timestamp will be placed in the right order. An unit test is
also added to ensure carbon line client protocol will send correct data
in the future.