### PR TITLE
Initial Python 3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,17 @@
 language: python
 python:
     - 2.7
+    - 3.4
+    - 3.5
+    - 3.6
     - pypy
-
-env:
-    - TOXENV=ci
 
 install:
     - pip install -r requirements.txt
     - python setup.py install --prefix=$VIRTUAL_ENV --install-lib=$VIRTUAL_ENV/lib/python$TRAVIS_PYTHON_VERSION/site-packages
-    - pip install tox
+    - pip install tox-travis
 
 script:
-    - tox -e $TOXENV
+    - tox
 
 sudo: false

--- a/bin/carbon-aggregator.py
+++ b/bin/carbon-aggregator.py
@@ -30,5 +30,5 @@ from carbon.exceptions import CarbonConfigException
 
 try:
     run_twistd_plugin(__file__)
-except CarbonConfigException, exc:
+except CarbonConfigException as exc:
     raise SystemExit(str(exc))

--- a/bin/carbon-cache.py
+++ b/bin/carbon-cache.py
@@ -30,5 +30,5 @@ from carbon.exceptions import CarbonConfigException
 
 try:
     run_twistd_plugin(__file__)
-except CarbonConfigException, exc:
+except CarbonConfigException as exc:
     raise SystemExit(str(exc))

--- a/bin/carbon-client.py
+++ b/bin/carbon-client.py
@@ -55,14 +55,14 @@ option_parser.add_option('--relayrules', default=default_relayrules,
 options, args = option_parser.parse_args()
 
 if not args:
-  print 'At least one host:port destination required\n'
+  print('At least one host:port destination required\n')
   option_parser.print_usage()
   raise SystemExit(1)
 
 if options.routing not in ('consistent-hashing', 'relay'):
-  print "Invalid --routing value, must be one of:"
-  print "  consistent-hashing"
-  print "  relay"
+  print("Invalid --routing value, must be one of:")
+  print("  consistent-hashing")
+  print("  relay")
   raise SystemExit(1)
 
 destinations = []
@@ -87,7 +87,7 @@ elif options.routing == 'relay':
   if exists(options.relayrules):
     router = RelayRulesRouter(options.relayrules)
   else:
-    print "relay rules file %s does not exist" % options.relayrules
+    print("relay rules file %s does not exist" % options.relayrules)
     raise SystemExit(1)
 
 client_manager = CarbonClientManager(router)

--- a/bin/carbon-relay.py
+++ b/bin/carbon-relay.py
@@ -30,5 +30,5 @@ from carbon.exceptions import CarbonConfigException
 
 try:
     run_twistd_plugin(__file__)
-except CarbonConfigException, exc:
+except CarbonConfigException as exc:
     raise SystemExit(str(exc))

--- a/bin/validate-storage-schemas.py
+++ b/bin/validate-storage-schemas.py
@@ -16,14 +16,18 @@ limitations under the License."""
 import sys
 import whisper
 from os.path import dirname, exists, join, realpath
-from ConfigParser import ConfigParser
+
+try:
+  from ConfigParser import ConfigParser
+except ImportError:
+  from configparser import ConfigParser
 
 if len(sys.argv) == 2:
   SCHEMAS_FILE = sys.argv[1]
-  print "Loading storage-schemas configuration from: '%s'" % SCHEMAS_FILE
+  print("Loading storage-schemas configuration from: '%s'" % SCHEMAS_FILE)
 else:
   SCHEMAS_FILE = realpath(join(dirname(__file__), '..', 'conf', 'storage-schemas.conf'))
-  print "Loading storage-schemas configuration from default location at: '%s'" % SCHEMAS_FILE
+  print("Loading storage-schemas configuration from default location at: '%s'" % SCHEMAS_FILE)
 
 config_parser = ConfigParser()
 if not config_parser.read(SCHEMAS_FILE):
@@ -32,7 +36,7 @@ if not config_parser.read(SCHEMAS_FILE):
 errors_found = 0
 
 for section in config_parser.sections():
-  print "Section '%s':" % section
+  print("Section '%s':" % section)
   options = dict(config_parser.items(section))
   retentions = options['retentions'].split(',')
 
@@ -41,26 +45,26 @@ for section in config_parser.sections():
   for retention in retentions:
     try:
       archives.append(whisper.parseRetentionDef(retention))
-    except ValueError, e:
-      print "  - Error: Section '%s' contains an invalid item in its retention definition ('%s')" % \
-        (section, retention)
-      print "    %s" % e.message
+    except ValueError as e:
+      print("  - Error: Section '%s' contains an invalid item in its retention definition ('%s')" % \
+        (section, retention))
+      print("    %s" % e.message)
       section_failed = True
 
   if not section_failed:
     try:
       whisper.validateArchiveList(archives)
-    except whisper.InvalidConfiguration, e:
-      print "  - Error: Section '%s' contains an invalid retention definition ('%s')" % \
-        (section, ','.join(retentions))
-      print "    %s" % e.message
+    except whisper.InvalidConfiguration as e:
+      print("  - Error: Section '%s' contains an invalid retention definition ('%s')" % \
+        (section, ','.join(retentions)))
+      print("    %s" % e.message)
 
   if section_failed:
     errors_found += 1
   else:
-    print "  OK"
+    print("  OK")
 
 if errors_found:
   raise SystemExit( "Storage-schemas configuration '%s' failed validation" % SCHEMAS_FILE)
 
-print "Storage-schemas configuration '%s' is valid" % SCHEMAS_FILE
+print("Storage-schemas configuration '%s' is valid" % SCHEMAS_FILE)

--- a/examples/example-client.py
+++ b/examples/example-client.py
@@ -50,9 +50,9 @@ def run(sock, delay):
         lines.append("system.loadavg_5min %s %d" % (loadavg[1], now))
         lines.append("system.loadavg_15min %s %d" % (loadavg[2], now))
         message = '\n'.join(lines) + '\n' #all lines must end in a newline
-        print "sending message"
-        print '-' * 80
-        print message
+        print("sending message")
+        print('-' * 80)
+        print(message)
         sock.sendall(message)
         time.sleep(delay)
 

--- a/examples/example-pickle-client.py
+++ b/examples/example-pickle-client.py
@@ -56,9 +56,9 @@ def run(sock, delay):
         lines.append("system.loadavg_5min %s %d" % (loadavg[1], now))
         lines.append("system.loadavg_15min %s %d" % (loadavg[2], now))
         message = '\n'.join(lines) + '\n' #all lines must end in a newline
-        print "sending message"
-        print '-' * 80
-        print message
+        print("sending message")
+        print('-' * 80)
+        print(message)
         package = pickle.dumps(tuples, 1)
         size = struct.pack('!L', len(package))
         sock.sendall(size)

--- a/lib/carbon/amqp_listener.py
+++ b/lib/carbon/amqp_listener.py
@@ -31,6 +31,11 @@ This program can be started standalone for testing or using carbon-cache.py
 (see example config file provided)
 """
 import sys
+
+# txamqp is currently not ported to py3
+if sys.version_info >= (3, 0):
+    raise ImportError
+
 import os
 import socket
 from optparse import OptionParser

--- a/lib/carbon/cache.py
+++ b/lib/carbon/cache.py
@@ -23,7 +23,8 @@ from carbon import events, log
 from carbon.pipeline import Processor
 
 
-def by_timestamp((timestamp, value)):  # useful sort key function
+def by_timestamp(t_v): # useful sort key function
+  (timestamp, _) = t_v
   return timestamp
 
 
@@ -57,14 +58,14 @@ class NaiveStrategy(DrainStrategy):
 
     def _generate_queue():
       while True:
-        metric_names = self.cache.keys()
+        metric_names = list(self.cache.keys())
         while metric_names:
           yield metric_names.pop()
 
     self.queue = _generate_queue()
 
   def choose_item(self):
-    return self.queue.next()
+    return next(self.queue)
 
 
 class MaxStrategy(DrainStrategy):
@@ -80,7 +81,7 @@ class MaxStrategy(DrainStrategy):
 class RandomStrategy(DrainStrategy):
   """Pop points randomly"""
   def choose_item(self):
-    return choice(self.cache.keys())
+    return choice(list(self.cache.keys()))
 
 
 class SortedStrategy(DrainStrategy):
@@ -105,7 +106,7 @@ class SortedStrategy(DrainStrategy):
     self.queue = _generate_queue()
 
   def choose_item(self):
-    return self.queue.next()
+    return next(self.queue)
 
 
 class TimeSortedStrategy(DrainStrategy):
@@ -130,7 +131,7 @@ class TimeSortedStrategy(DrainStrategy):
     self.queue = _generate_queue()
 
   def choose_item(self):
-    return self.queue.next()
+    return next(self.queue)
 
 
 class _MetricCache(defaultdict):
@@ -174,7 +175,7 @@ class _MetricCache(defaultdict):
       metric = self.strategy.choose_item()
     else:
       # Avoid .keys() as it dumps the whole list
-      metric = self.iterkeys().next()
+      metric = next(iter(self.keys()))
     return (metric, self.pop(metric))
 
   def get_datapoints(self, metric):

--- a/lib/carbon/client.py
+++ b/lib/carbon/client.py
@@ -1,5 +1,6 @@
 from collections import deque
 from time import time
+from six import with_metaclass
 
 from twisted.application.service import Service
 from twisted.internet import reactor
@@ -169,8 +170,7 @@ class CarbonClientProtocol(object):
   __repr__ = __str__
 
 
-class CarbonClientFactory(object, ReconnectingClientFactory):
-  __metaclass__ = PluginRegistrar
+class CarbonClientFactory(with_metaclass(PluginRegistrar, ReconnectingClientFactory, object)):
   plugins = {}
   maxDelay = 5
 
@@ -476,8 +476,8 @@ class CarbonClientManager(Service):
     factory_class = CarbonClientFactory.plugins.get(factory_name)
 
     if not factory_class:
-      print ("In carbon.conf, DESTINATION_PROTOCOL must be one of %s. "
-             "Invalid value: '%s'" % (', '.join(CarbonClientFactory.plugins), factory_name))
+      print("In carbon.conf, DESTINATION_PROTOCOL must be one of %s. "
+            "Invalid value: '%s'" % (', '.join(CarbonClientFactory.plugins), factory_name))
       raise SystemExit(1)
 
     return factory_class(destination, self.router)

--- a/lib/carbon/client.py
+++ b/lib/carbon/client.py
@@ -402,7 +402,7 @@ class CarbonClientFactory(with_metaclass(PluginRegistrar, ReconnectingClientFact
 class CarbonPickleClientProtocol(CarbonClientProtocol, Int32StringReceiver):
 
   def _sendDatapointsNow(self, datapoints):
-    self.sendString(pickle.dumps(datapoints, protocol=-1))
+    self.sendString(pickle.dumps(datapoints, protocol=2))
 
 
 class CarbonPickleClientFactory(CarbonClientFactory):

--- a/lib/carbon/database.py
+++ b/lib/carbon/database.py
@@ -16,11 +16,11 @@ import os
 from os.path import exists, dirname, join, sep
 from carbon.util import PluginRegistrar
 from carbon import log
+from six import with_metaclass
 
 
-class TimeSeriesDatabase(object):
+class TimeSeriesDatabase(with_metaclass(PluginRegistrar, object)):
   "Abstract base class for Carbon database backends."
-  __metaclass__ = PluginRegistrar
   plugins = {}
 
   "List of supported aggregation methods for the database."
@@ -108,7 +108,7 @@ else:
       try:
         if not exists(directory):
           os.makedirs(directory)
-      except OSError, e:
+      except OSError as e:
         log.err("%s" % e)
 
       whisper.create(path, retentions, xfilesfactor, aggregation_method,
@@ -135,7 +135,7 @@ else:
     def validateArchiveList(self, archiveList):
       try:
         whisper.validateArchiveList(archiveList)
-      except whisper.InvalidConfiguration, e:
+      except whisper.InvalidConfiguration as e:
         raise ValueError("%s" % e)
 
 

--- a/lib/carbon/hashing.py
+++ b/lib/carbon/hashing.py
@@ -3,6 +3,7 @@ try:
 except ImportError:
   from md5 import md5
 import bisect
+import sys
 
 
 class ConsistentHashRing:
@@ -14,7 +15,10 @@ class ConsistentHashRing:
       self.add_node(node)
 
   def compute_ring_position(self, key):
-    big_hash = md5(str(key)).hexdigest()
+    if sys.version_info >= (3, 0):
+      big_hash = md5(key.encode('utf-8')).hexdigest()
+    else:
+      big_hash = md5(key).hexdigest()
     small_hash = int(big_hash[:4], 16)
     return small_hash
 

--- a/lib/carbon/hashing.py
+++ b/lib/carbon/hashing.py
@@ -36,7 +36,7 @@ class ConsistentHashRing:
     assert self.ring
     node = None
     node_iter = self.get_nodes(key)
-    node = node_iter.next()
+    node = next(node_iter)
     node_iter.close()
     return node
 
@@ -50,7 +50,7 @@ class ConsistentHashRing:
         return
     nodes = set()
     position = self.compute_ring_position(key)
-    search_entry = (position, None)
+    search_entry = (position, ())
     index = bisect.bisect_left(self.ring, search_entry) % len(self.ring)
     last_index = (index - 1) % len(self.ring)
     while len(nodes) < len(self.nodes) and index != last_index:

--- a/lib/carbon/log.py
+++ b/lib/carbon/log.py
@@ -1,7 +1,7 @@
 import os
 import time
 from sys import stdout, stderr
-from zope.interface import implements
+from zope.interface import implementer
 from twisted.python.log import startLoggingWithObserver, textFromEventDict, msg, err, ILogObserver
 from twisted.python.syslog import SyslogObserver
 from twisted.python.logfile import DailyLogFile
@@ -19,7 +19,7 @@ class CarbonLogFile(DailyLogFile):
     """
     Fix Umask Issue https://twistedmatrix.com/trac/ticket/7026
     """
-    openMode = self.defaultMode or 0777
+    openMode = self.defaultMode or 0o777
     self._file = os.fdopen(os.open(
       self.path, os.O_CREAT|os.O_RDWR, openMode), 'r+', 1)
     self.closed = False
@@ -59,8 +59,8 @@ class CarbonLogFile(DailyLogFile):
     self._openFile()
 
 
+@implementer(ILogObserver)
 class CarbonLogObserver(object):
-  implements(ILogObserver)
 
   def log_to_dir(self, logdir):
     self.logdir = logdir

--- a/lib/carbon/pipeline.py
+++ b/lib/carbon/pipeline.py
@@ -1,9 +1,9 @@
 from carbon.util import PluginRegistrar
 from carbon import state, log
+from six import with_metaclass
 
 
-class Processor(object):
-  __metaclass__ = PluginRegistrar
+class Processor(with_metaclass(PluginRegistrar, object)):
   plugins = {}
   NO_OUTPUT = ()
 

--- a/lib/carbon/protocols.py
+++ b/lib/carbon/protocols.py
@@ -134,15 +134,13 @@ class MetricReceiver(CarbonServerProtocol, TimeoutMixin):
       events.resumeReceivingMetrics.removeHandler(self.resumeReceiving)
 
   def metricReceived(self, metric, datapoint):
-    if settings.USE_WHITELIST:
-      if metric in BlackList:
-        instrumentation.increment('blacklistMatches')
-        log.debug("metric {} dropped: in blacklist")
-        return
-      if metric not in WhiteList:
-        instrumentation.increment('whitelistRejects')
-        log.debug("metric {} dropped: not in whitelist")
-        return
+    if BlackList and metric in BlackList:
+      instrumentation.increment('blacklistMatches')
+      return
+    if WhiteList and metric not in WhiteList:
+      instrumentation.increment('whitelistRejects')
+      return
+
     if datapoint[1] != datapoint[1]:  # filter out NaN values
       return
     if int(datapoint[0]) == -1:  # use current time if none given: https://github.com/graphite-project/carbon/issues/54

--- a/lib/carbon/protocols.py
+++ b/lib/carbon/protocols.py
@@ -283,7 +283,7 @@ class CacheManagementHandler(Int32StringReceiver):
     else:
       result = dict(error="Invalid request type \"%s\"" % request['type'])
 
-    response = pickle.dumps(result, protocol=-1)
+    response = pickle.dumps(result, protocol=2)
     self.sendString(response)
 
 

--- a/lib/carbon/regexlist.py
+++ b/lib/carbon/regexlist.py
@@ -57,6 +57,7 @@ class RegexList:
   def __nonzero__(self):
     return bool(self.regex_list)
 
+  __bool__ = __nonzero__  # py2/3 compatibility
 
 WhiteList = RegexList()
 BlackList = RegexList()

--- a/lib/carbon/routers.py
+++ b/lib/carbon/routers.py
@@ -1,11 +1,12 @@
 import imp
 from carbon.hashing import ConsistentHashRing
 from carbon.util import PluginRegistrar
+from six import with_metaclass
+from six.moves import xrange
 
 
-class DatapointRouter(object):
+class DatapointRouter(with_metaclass(PluginRegistrar, object)):
   "Abstract base class for datapoint routing logic implementations"
-  __metaclass__ = PluginRegistrar
   plugins = {}
 
   def addDestination(self, destination):

--- a/lib/carbon/service.py
+++ b/lib/carbon/service.py
@@ -38,7 +38,7 @@ except ImportError:
   pass
 try:
   import carbon.protobuf
-except ImportError, e:
+except ImportError as e:
   pass
 
 

--- a/lib/carbon/storage.py
+++ b/lib/carbon/storage.py
@@ -103,7 +103,7 @@ def loadStorageSchemas():
       if state.database is not None:
         state.database.validateArchiveList(archiveList)
       schemaList.append(mySchema)
-    except ValueError, e:
+    except ValueError as e:
       log.msg("Invalid schemas found in %s: %s" % (section, e))
 
   schemaList.append(defaultSchema)

--- a/lib/carbon/tests/benchmark_aggregator.py
+++ b/lib/carbon/tests/benchmark_aggregator.py
@@ -36,7 +36,7 @@ def bench_aggregator_fake():
 
 
 def _bench_aggregator(name):
-    print "== %s ==" % name
+    print("== %s ==" % name)
     max_intervals = settings['MAX_AGGREGATION_INTERVALS']
     now = time.time() - (max_intervals * FREQUENCY)
 
@@ -59,7 +59,7 @@ def _bench_aggregator(name):
         t = timeit.timeit(_process, number=n)
         buf.close()
         print_stats(n, t)
-    print ""
+    print("")
 
 
 def main():

--- a/lib/carbon/tests/benchmark_cache.py
+++ b/lib/carbon/tests/benchmark_cache.py
@@ -32,34 +32,34 @@ def command_drain():
 def print_stats(n, t):
     usec = t * 1e6
     if usec < 1000:
-        print "    datapoints: %-10d usecs: %d" % (n, int(usec))
+        print("    datapoints: %-10d usecs: %d" % (n, int(usec)))
     else:
         msec = usec / 1000
         if msec < 1000:
-            print "    datapoints: %-10d msecs: %d" % (n, int(msec))
+            print("    datapoints: %-10d msecs: %d" % (n, int(msec)))
         else:
             sec = msec / 1000
-            print "    datapoints: %-10d  secs: %3g" % (n, sec)
+            print("    datapoints: %-10d  secs: %3g" % (n, sec))
 
 
 if __name__ == '__main__':
-    print "Benchmarking single metric MetricCache store..."
+    print("Benchmarking single metric MetricCache store...")
     for n in [1000, 10000, 100000, 1000000]:
         count = 0
         metric_cache = _MetricCache(DrainStrategy)
         t = timeit.timeit(command_store_foo, number=n)
         print_stats(n, t)
 
-    print "Benchmarking unique metric MetricCache store..."
+    print("Benchmarking unique metric MetricCache store...")
     for n in [1000, 10000, 100000, 1000000]:
         count = 0
         metric_cache = _MetricCache(DrainStrategy)
         t = timeit.timeit(command_store_foo_n, number=n)
         print_stats(n, t)
 
-    print "Benchmarking single metric MetricCache drain..."
+    print("Benchmarking single metric MetricCache drain...")
     for name, strategy in sorted(strategies.items()):
-        print "CACHE_WRITE_STRATEGY: %s" % name
+        print("CACHE_WRITE_STRATEGY: %s" % name)
         for n in [1000, 10000, 100000, 1000000]:
             count = 0
             metric_cache = _MetricCache(strategy)
@@ -67,13 +67,13 @@ if __name__ == '__main__':
             t = timeit.timeit(command_drain, number=1)
             print_stats(n, t)
 
-    print "Benchmarking unique metric MetricCache drain..."
+    print("Benchmarking unique metric MetricCache drain...")
     for name, strategy in sorted(strategies.items()):
-        print "CACHE_WRITE_STRATEGY: %s" % name
+        print("CACHE_WRITE_STRATEGY: %s" % name)
         for n in [1000, 10000, 100000, 1000000]:
             # remove me when strategy is fast
             if (name == 'max' and n > 10000) or (name == 'random' and n > 100000):
-                print "    datapoints: %-10d [skipped]" % n
+                print("    datapoints: %-10d [skipped]" % n)
                 continue
             count = 0
             metric_cache = _MetricCache(strategy)

--- a/lib/carbon/tests/benchmark_routers.py
+++ b/lib/carbon/tests/benchmark_routers.py
@@ -3,6 +3,7 @@ import timeit
 
 from carbon.routers import DatapointRouter
 from test_routers import createSettings
+from six.moves import xrange
 
 
 REPLICATION_FACTORS = [1, 4]
@@ -21,7 +22,7 @@ def print_stats(r, t):
     else:
         sec = msec / 1000
         text += " secs: %3g" % sec
-    print text
+    print(text)
 
 
 def generateDestinations(n):

--- a/lib/carbon/tests/test_aggregator_buffers.py
+++ b/lib/carbon/tests/test_aggregator_buffers.py
@@ -107,7 +107,7 @@ class AggregationMetricBufferTest(TestCase):
     interval_buffer.input((600, 1.0))
     self.metric_buffer.interval_buffers[600] = interval_buffer
 
-    with patch.object(interval_buffer, 'mark_inactive') as mark_inactive_mock:
+    with patch.object(IntervalBuffer, 'mark_inactive') as mark_inactive_mock:
       self.metric_buffer.compute_value()
       mark_inactive_mock.assert_called_once_with()
 
@@ -201,7 +201,7 @@ class AggregationMetricBufferTest(TestCase):
     BufferManager.buffers['carbon.foo.bar'] = self.metric_buffer
 
     with patch("time.time", new=Mock(return_value=current_interval + 60)):
-      with patch.object(self.metric_buffer, 'close') as close_mock:
+      with patch.object(MetricBuffer, 'close') as close_mock:
         self.metric_buffer.compute_value()
         close_mock.assert_called_once_with()
 
@@ -220,6 +220,6 @@ class AggregationMetricBufferTest(TestCase):
       self.assertFalse('carbon.foo.bar' in BufferManager.buffers)
 
   def test_close_stops_looping_call(self):
-    with patch.object(self.metric_buffer, 'close') as close_mock:
+    with patch.object(MetricBuffer, 'close') as close_mock:
       self.metric_buffer.close()
       close_mock.assert_called_once_with()

--- a/lib/carbon/tests/test_cache.py
+++ b/lib/carbon/tests/test_cache.py
@@ -36,7 +36,7 @@ class MetricCacheTest(TestCase):
   def test_store_new_metric(self):
     self.metric_cache.store('foo', (123456, 1.0))
     self.assertEqual(1, self.metric_cache.size)
-    self.assertEqual([(123456, 1.0)], self.metric_cache['foo'].items())
+    self.assertEqual([(123456, 1.0)], list(self.metric_cache['foo'].items()))
 
   def test_store_multiple_datapoints(self):
     self.metric_cache.store('foo', (123456, 1.0))
@@ -50,7 +50,7 @@ class MetricCacheTest(TestCase):
     self.metric_cache.store('foo', (123456, 1.0))
     self.metric_cache.store('foo', (123456, 2.0))
     self.assertEqual(1, self.metric_cache.size)
-    self.assertEqual([(123456, 2.0)], self.metric_cache['foo'].items())
+    self.assertEqual([(123456, 2.0)], list(self.metric_cache['foo'].items()))
 
   def test_store_checks_fullness(self):
     is_full_mock = PropertyMock()

--- a/lib/carbon/tests/test_conf.py
+++ b/lib/carbon/tests/test_conf.py
@@ -88,7 +88,7 @@ class ReadConfigTest(MockerTestCase):
         """
         try:
             read_config("carbon-foo", FakeOptions(config=None))
-        except CarbonConfigException, e:
+        except CarbonConfigException as e:
             self.assertEqual("Either ROOT_DIR or GRAPHITE_ROOT "
                              "needs to be provided.", str(e))
         else:

--- a/lib/carbon/tests/test_conf.py
+++ b/lib/carbon/tests/test_conf.py
@@ -1,8 +1,9 @@
 import os
+from tempfile import mkdtemp, mkstemp
+from shutil import rmtree
 from os import makedirs
 from os.path import dirname, join
 from unittest import TestCase
-from mocker import MockerTestCase
 from carbon.conf import get_default_parser, parse_options, read_config
 from carbon.exceptions import CarbonConfigException
 
@@ -80,7 +81,25 @@ class ParseOptionsTest(TestCase):
         self.assertEqual(("start",), args)
 
 
-class ReadConfigTest(MockerTestCase):
+class ReadConfigTest(TestCase):
+
+    def makeFile(self, content=None, basename=None, dirname=None):
+        """
+        Create a temporary file with content
+        Deletes the file after tests
+        """
+        if basename is not None:
+            path = join(dirname, basename)
+        else:
+            fd, path = mkstemp(dir=dirname)
+            os.close(fd)
+            self.addCleanup(os.unlink, path)
+
+        if content is not None:
+            with open(path, "w") as f:
+                f.write(content)
+
+        return path
 
     def test_root_dir_is_required(self):
         """
@@ -99,7 +118,8 @@ class ReadConfigTest(MockerTestCase):
         If the '--config' option is not provided, it defaults to
         ROOT_DIR/conf/carbon.conf.
         """
-        root_dir = self.makeDir()
+        root_dir = mkdtemp()
+        self.addCleanup(rmtree, root_dir)
         conf_dir = join(root_dir, "conf")
         makedirs(conf_dir)
         self.makeFile(content="[foo]",
@@ -116,7 +136,8 @@ class ReadConfigTest(MockerTestCase):
         If the 'GRAPHITE_CONFIG_DIR' variable is set in the environment, then
         'CONFIG_DIR' will be set to that directory.
         """
-        root_dir = self.makeDir()
+        root_dir = mkdtemp()
+        self.addCleanup(rmtree, root_dir)
         conf_dir = join(root_dir, "configs", "production")
         makedirs(conf_dir)
         self.makeFile(content="[foo]",

--- a/lib/carbon/tests/test_protocols.py
+++ b/lib/carbon/tests/test_protocols.py
@@ -1,3 +1,4 @@
+from sys import version_info
 from carbon.protocols import MetricReceiver
 from unittest import TestCase
 from mock import Mock, patch
@@ -9,7 +10,11 @@ import pickle
 
 class TestMetricReceiversHandler(TestCase):
   def test_build(self):
-    expected_plugins = sorted(['line', 'udp', 'pickle', 'amqp', 'protobuf'])
+    # amqp not supported with py3
+    if version_info >= (3, 0):
+      expected_plugins = sorted(['line', 'udp', 'pickle', 'protobuf'])
+    else:
+     expected_plugins = sorted(['line', 'udp', 'pickle', 'amqp', 'protobuf'])
 
     # Can't always test manhole because 'cryptography' can
     # be a pain to install and we don't want to make the CI

--- a/lib/carbon/tests/test_service.py
+++ b/lib/carbon/tests/test_service.py
@@ -1,4 +1,3 @@
-import exceptions
 from mock import Mock, patch
 from unittest import TestCase
 
@@ -51,7 +50,7 @@ class TestSetupPipeline(TestCase):
 
   def test_unknown_processor_raises_value_error(self):
     self.assertRaises(
-        exceptions.ValueError, setupPipeline, ['foo'], self.root_service_mock, self.settings)
+        ValueError, setupPipeline, ['foo'], self.root_service_mock, self.settings)
 
   @patch('carbon.service.setupRewriterProcessor', new=Mock())
   def test_parses_processor_args(self):

--- a/lib/carbon/util.py
+++ b/lib/carbon/util.py
@@ -225,7 +225,10 @@ else:
 
     @classmethod
     def loads(cls, pickle_string):
-      return cls(StringIO(pickle_string)).load()
+      if sys.version_info >= (3, 0):
+        return cls(StringIO(pickle_string), encoding='utf-8').load()
+      else:
+        return cls(StringIO(pickle_string)).load()
 
 
 def get_unpickler(insecure=False):

--- a/lib/carbon/util.py
+++ b/lib/carbon/util.py
@@ -1,13 +1,24 @@
 import sys
 import os
 import pwd
-import __builtin__
+
+try:
+  import builtins as __builtin__
+except ImportError:
+  import __builtin__
 
 from os.path import abspath, basename, dirname
-try:
-  from cStringIO import StringIO
-except ImportError:
-  from StringIO import StringIO
+
+# BytesIO is needed on py3 as StringIO does not operate on byte input anymore
+# We could use BytesIO on py2 as well but it is slower than StringIO
+if sys.version_info >= (3, 0):
+  from io import BytesIO as StringIO
+else:
+  try:
+    from cStringIO import StringIO
+  except ImportError:
+    from StringIO import StringIO
+
 try:
   import cPickle as pickle
   USING_CPICKLE = True

--- a/lib/carbon/writer.py
+++ b/lib/carbon/writer.py
@@ -111,7 +111,7 @@ def writeCachedDataPoints():
         try:
             state.database.create(metric, archiveConfig, xFilesFactor, aggregationMethod)
             instrumentation.increment('creates')
-        except Exception, e:
+        except Exception as e:
             log.err()
             log.msg("Error creating %s: %s" % (metric, e))
             instrumentation.increment('errors')
@@ -127,7 +127,7 @@ def writeCachedDataPoints():
         datapoints = dict(datapoints).items()
         state.database.write(metric, datapoints)
         updateTime = time.time() - t1
-      except Exception, e:
+      except Exception as e:
         log.err()
         log.msg("Error writing to %s: %s" % (metric, e))
         instrumentation.increment('errors')
@@ -160,7 +160,7 @@ def reloadStorageSchemas():
   global SCHEMAS
   try:
     SCHEMAS = loadStorageSchemas()
-  except Exception, e:
+  except Exception as e:
     log.msg("Failed to reload storage SCHEMAS: %s" % (e))
 
 
@@ -168,7 +168,7 @@ def reloadAggregationSchemas():
   global AGGREGATION_SCHEMAS
   try:
     AGGREGATION_SCHEMAS = loadAggregationSchemas()
-  except Exception, e:
+  except Exception as e:
     log.msg("Failed to reload aggregation SCHEMAS: %s" % (e))
 
 

--- a/lib/twisted/plugins/carbon_aggregator_cache_plugin.py
+++ b/lib/twisted/plugins/carbon_aggregator_cache_plugin.py
@@ -1,4 +1,4 @@
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.plugin import IPlugin
 from twisted.application.service import IServiceMaker
@@ -6,9 +6,9 @@ from twisted.application.service import IServiceMaker
 from carbon import conf
 
 
+@implementer(IServiceMaker, IPlugin)
 class CarbonAggregatorCacheServiceMaker(object):
 
-    implements(IServiceMaker, IPlugin)
     tapname = "carbon-aggregator-cache"
     description = "Aggregate and write stats for graphite."
     options = conf.CarbonAggregatorOptions

--- a/lib/twisted/plugins/carbon_aggregator_plugin.py
+++ b/lib/twisted/plugins/carbon_aggregator_plugin.py
@@ -1,14 +1,13 @@
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.plugin import IPlugin
 from twisted.application.service import IServiceMaker
 
 from carbon import conf
 
-
+@implementer(IServiceMaker, IPlugin)
 class CarbonAggregatorServiceMaker(object):
 
-    implements(IServiceMaker, IPlugin)
     tapname = "carbon-aggregator"
     description = "Aggregate stats for graphite."
     options = conf.CarbonAggregatorOptions

--- a/lib/twisted/plugins/carbon_cache_plugin.py
+++ b/lib/twisted/plugins/carbon_cache_plugin.py
@@ -1,4 +1,4 @@
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.plugin import IPlugin
 from twisted.application.service import IServiceMaker
@@ -6,9 +6,9 @@ from twisted.application.service import IServiceMaker
 from carbon import conf
 
 
+@implementer(IServiceMaker, IPlugin)
 class CarbonCacheServiceMaker(object):
 
-    implements(IServiceMaker, IPlugin)
     tapname = "carbon-cache"
     description = "Collect stats for graphite."
     options = conf.CarbonCacheOptions

--- a/lib/twisted/plugins/carbon_relay_plugin.py
+++ b/lib/twisted/plugins/carbon_relay_plugin.py
@@ -1,4 +1,4 @@
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.plugin import IPlugin
 from twisted.application.service import IServiceMaker
@@ -6,9 +6,9 @@ from twisted.application.service import IServiceMaker
 from carbon import conf
 
 
+@implementer(IServiceMaker, IPlugin)
 class CarbonRelayServiceMaker(object):
 
-    implements(IServiceMaker, IPlugin)
     tapname = "carbon-relay"
     description = "Relay stats for graphite."
     options = conf.CarbonRelayOptions

--- a/setup.py
+++ b/setup.py
@@ -3,44 +3,8 @@
 from __future__ import with_statement
 
 import os
-import ConfigParser
-
 import platform
 from glob import glob
-
-try:
-    from io import BytesIO
-except ImportError:
-    from StringIO import StringIO as BytesIO
-
-# Graphite historically has an install prefix set in setup.cfg. Being in a
-# configuration file, it's not easy to override it or unset it (for installing
-# graphite in a virtualenv for instance).
-# The prefix is now set by ``setup.py`` and *unset* if an environment variable
-# named ``GRAPHITE_NO_PREFIX`` is present.
-# While ``setup.cfg`` doesn't contain the prefix anymore, the *unset* step is
-# required for installations from a source tarball because running
-# ``python setup.py sdist`` will re-add the prefix to the tarball's
-# ``setup.cfg``.
-with open('setup.cfg', 'r') as f:
-    orig_setup_cfg = f.read()
-cf = ConfigParser.ConfigParser()
-cf.readfp(BytesIO(orig_setup_cfg), 'setup.cfg')
-
-if os.environ.get('GRAPHITE_NO_PREFIX'):
-    cf.remove_section('install')
-else:
-    try:
-        cf.add_section('install')
-    except ConfigParser.DuplicateSectionError:
-        pass
-    if not cf.has_option('install', 'prefix'):
-        cf.set('install', 'prefix', '/opt/graphite')
-    if not cf.has_option('install', 'install-lib'):
-        cf.set('install', 'install-lib', '%(prefix)s/lib')
-
-with open('setup.cfg', 'wb') as f:
-    cf.write(f)
 
 if os.environ.get('USE_SETUPTOOLS'):
   from setuptools import setup
@@ -65,23 +29,23 @@ init_scripts = [ ('examples/init.d', ['distro/redhat/init.d/carbon-cache',
                                       'distro/redhat/init.d/carbon-aggregator']) ]
 install_files += init_scripts
 
-try:
-    setup(
-      name='carbon',
-      version='1.1.0',
-      url='http://graphiteapp.org/',
-      author='Chris Davis',
-      author_email='chrismd@gmail.com',
-      license='Apache Software License 2.0',
-      description='Backend data caching and persistence daemon for Graphite',
-      long_description='Backend data caching and persistence daemon for Graphite',
-      packages=['carbon', 'carbon.aggregator', 'twisted.plugins'],
-      package_dir={'' : 'lib'},
-      scripts=glob('bin/*'),
-      package_data={ 'carbon' : ['*.xml'] },
-      data_files=install_files,
-      install_requires=['Twisted', 'txAMQP', 'cachetools'],
-      classifiers=(
+
+setup(
+    name='carbon',
+    version='1.1.0',
+    url='http://graphiteapp.org/',
+    author='Chris Davis',
+    author_email='chrismd@gmail.com',
+    license='Apache Software License 2.0',
+    description='Backend data caching and persistence daemon for Graphite',
+    long_description='Backend data caching and persistence daemon for Graphite',
+    packages=['carbon', 'carbon.aggregator', 'twisted.plugins'],
+    package_dir={'' : 'lib'},
+    scripts=glob('bin/*'),
+    package_data={ 'carbon' : ['*.xml'] },
+    data_files=install_files,
+    install_requires=['Twisted', 'txAMQP', 'cachetools'],
+    classifiers=(
         'Intended Audience :: Developers',
         'Natural Language :: English',
         'License :: OSI Approved :: Apache Software License',
@@ -89,10 +53,7 @@ try:
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 2 :: Only',
-      ),
+    ),
 
-      **setup_kwargs
-    )
-finally:
-    with open('setup.cfg', 'w') as f:
-        f.write(orig_setup_cfg)
+    **setup_kwargs
+)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ from glob import glob
 if os.environ.get('USE_SETUPTOOLS'):
   from setuptools import setup
   setup_kwargs = dict(zip_safe=0)
-
 else:
   from distutils.core import setup
   setup_kwargs = dict()
@@ -52,8 +51,10 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 2 :: Only',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ),
-
     **setup_kwargs
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,20 @@
+[tox]
+envlist =
+  py27,
+  py34,
+  py35,
+  py36,
+  pypy,
+
 [testenv]
 setenv =
   GRAPHITE_NO_PREFIX=true
   PYTHONPATH={toxinidir}/lib
 commands =
-  /bin/true
+  trial carbon
 deps =
      -rrequirements.txt
      -rtests-requirements.txt
-
-[testenv:ci]
-commands =
-  trial carbon
 
 [testenv:lint]
 deps =
@@ -22,7 +26,8 @@ commands =
 voting = False
 commands =
   python {toxinidir}/lib/carbon/tests/benchmark_cache.py
+  python {toxinidir}/lib/carbon/tests/benchmark_routers.py
 
 [flake8]
 max-line-length=100
-ignore=E111,E121
+ignore=E111,E114,E121


### PR DESCRIPTION
Adds initial python3 compatibility. All unittests and benchmark now succeed on py27, py34, py35, py36. But needs real-life testing.

While updating the GRAPHITE_NO_PREFIX part in setup.py I noticed that the original didn't work on my system with Python 2.7. It would just write an empty setup.cfg file. Instead of fixing the original code I just removed that part as I understand from comments in other issues that it is not needed anymore and I personally think the prefix should not be the default behaviour.

AMQP is disabled on python3 as the modules are not compatible yet.

mocker is also not compatible yet, I've added a simplified makeFile function to the testcase and removed the import of mocker.

For the hashring the "node:instance" string needs to be encoded, I've encoded it with ascii as I was not sure if UTF-8 would cause trouble somewhere else.
