### PR TITLE
Add carbon-cache-aggregator

### DIFF
--- a/bin/carbon-aggregator-cache.py
+++ b/bin/carbon-aggregator-cache.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+"""Copyright 2009 Chris Davis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License."""
+
+import sys
+import os.path
+
+# Figure out where we're installed
+BIN_DIR = os.path.dirname(os.path.abspath(__file__))
+ROOT_DIR = os.path.dirname(BIN_DIR)
+
+# Make sure that carbon's 'lib' dir is in the $PYTHONPATH if we're running from
+# source.
+LIB_DIR = os.path.join(ROOT_DIR, "lib")
+sys.path.insert(0, LIB_DIR)
+
+from carbon.util import run_twistd_plugin
+from carbon.exceptions import CarbonConfigException
+
+try:
+    run_twistd_plugin(__file__)
+except CarbonConfigException, exc:
+    raise SystemExit(str(exc))

--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -499,7 +499,7 @@ def get_default_parser(usage="%prog [options] <start|stop|status>"):
 
 def get_parser(name):
     parser = get_default_parser()
-    if name == "carbon-aggregator":
+    if "carbon-aggregator" in name:
         parser.add_option(
             "--rules",
             default=None,

--- a/lib/carbon/instrumentation.py
+++ b/lib/carbon/instrumentation.py
@@ -78,7 +78,7 @@ def recordMetrics():
   stats.clear()
 
   # cache metrics
-  if settings.program == 'carbon-cache':
+  if 'cache' in settings.program:
     record = cache_record
     updateTimes = myStats.get('updateTimes', [])
     committedPoints = myStats.get('committedPoints', 0)
@@ -119,7 +119,7 @@ def recordMetrics():
     record('cache.overflow', cacheOverflow)
 
   # aggregator metrics
-  elif settings.program == 'carbon-aggregator':
+  elif 'aggregator' in settings.program:
     record = aggregator_record
     record('allocatedBuffers', len(BufferManager))
     record('bufferedDatapoints',

--- a/lib/twisted/plugins/carbon_aggregator_cache_plugin.py
+++ b/lib/twisted/plugins/carbon_aggregator_cache_plugin.py
@@ -1,0 +1,25 @@
+from zope.interface import implements
+
+from twisted.plugin import IPlugin
+from twisted.application.service import IServiceMaker
+
+from carbon import conf
+
+
+class CarbonAggregatorCacheServiceMaker(object):
+
+    implements(IServiceMaker, IPlugin)
+    tapname = "carbon-aggregator-cache"
+    description = "Aggregate and write stats for graphite."
+    options = conf.CarbonAggregatorOptions
+
+    def makeService(self, options):
+        """
+        Construct a C{carbon-aggregator-cache} service.
+        """
+        from carbon import service
+        return service.createAggregatorCacheService(options)
+
+
+# Now construct an object which *provides* the relevant interfaces
+serviceMaker = CarbonAggregatorCacheServiceMaker()


### PR DESCRIPTION
This avoids network and CPU overhead between cache and aggregators since
they often receive the same metrics. Most of the CPU was found to be used in
the serializing and deserializing functions.