### PR TITLE
fix 'retentions' key error when loading storage schema

### DIFF
--- a/lib/carbon/storage.py
+++ b/lib/carbon/storage.py
@@ -85,7 +85,7 @@ def loadStorageSchemas():
     pattern = options.get('pattern')
 
     try:
-      retentions = options['retentions'].split(',')
+      retentions = options.get('retentions').split(',')
       archives = [Archive.fromString(s) for s in retentions]
     except KeyError:
       log.err("Schema %s missing 'retentions', skipping" % section)


### PR DESCRIPTION
Previously throwing a key error. value incorrectly accessed, modified to match method used for parsing other options.