### PR TITLE
py3: fix iterkeys() and exception.message

### DIFF
--- a/bin/validate-storage-schemas.py
+++ b/bin/validate-storage-schemas.py
@@ -48,7 +48,7 @@ for section in config_parser.sections():
     except ValueError as e:
       print("  - Error: Section '%s' contains an invalid item in its retention definition ('%s')" % \
         (section, retention))
-      print("    %s" % e.message)
+      print("    %s" % e)
       section_failed = True
 
   if not section_failed:
@@ -57,7 +57,7 @@ for section in config_parser.sections():
     except whisper.InvalidConfiguration as e:
       print("  - Error: Section '%s' contains an invalid retention definition ('%s')" % \
         (section, ','.join(retentions)))
-      print("    %s" % e.message)
+      print("    %s" % e)
 
   if section_failed:
     errors_found += 1

--- a/lib/carbon/cache.py
+++ b/lib/carbon/cache.py
@@ -180,7 +180,7 @@ class _MetricCache(defaultdict):
       metric = self.strategy.choose_item()
     else:
       # Avoid .keys() as it dumps the whole list
-      metric = next(iter(self.keys()))
+      metric = next(iter(self))
     return (metric, self.pop(metric))
 
   def get_datapoints(self, metric):


### PR DESCRIPTION
d.iterkeys() should be iter(d) instead of iter(d.keys()) so it doesn't return
a whole list but only the iterators.

exception.message doesn't exits in Python3