### PR TITLE
Backporting fnv1a_hash ring from graphite-web

### DIFF
--- a/lib/carbon/hashing.py
+++ b/lib/carbon/hashing.py
@@ -5,27 +5,56 @@ except ImportError:
 import bisect
 import sys
 
+try:
+  import pyhash
+  hasher = pyhash.fnv1a_32()
+  def fnv32a(string, seed=0x811c9dc5):
+    return hasher(string, seed=seed)
+except ImportError:
+  def fnv32a(string, seed=0x811c9dc5):
+    """
+    FNV-1a Hash (http://isthe.com/chongo/tech/comp/fnv/) in Python.
+    Taken from https://gist.github.com/vaiorabbit/5670985
+    """
+    hval = seed
+    fnv_32_prime = 0x01000193
+    uint32_max = 2 ** 32
+    for s in string:
+      hval = hval ^ ord(s)
+      hval = (hval * fnv_32_prime) % uint32_max
+    return hval
 
 class ConsistentHashRing:
-  def __init__(self, nodes, replica_count=100):
+  def __init__(self, nodes, replica_count=100, hash_type='carbon_ch'):
     self.ring = []
     self.nodes = set()
     self.replica_count = replica_count
+    self.hash_type = hash_type
     for node in nodes:
       self.add_node(node)
 
   def compute_ring_position(self, key):
-    if sys.version_info >= (3, 0):
-      big_hash = md5(key.encode('utf-8')).hexdigest()
+    if self.hash_type == 'fnv1a_ch':
+      if sys.version_info >= (3, 0):
+        big_hash = '{:x}'.format(int(fnv32a(key)))
+      else:
+        big_hash = '{:x}'.format(int(fnv32a(str(key))))
+      small_hash = int(big_hash[:4], 16) ^ int(big_hash[4:], 16)
     else:
-      big_hash = md5(key).hexdigest()
-    small_hash = int(big_hash[:4], 16)
+      if sys.version_info >= (3, 0):
+        big_hash = md5(key.encode('utf-8')).hexdigest()
+      else:
+        big_hash = md5(key).hexdigest()
+      small_hash = int(big_hash[:4], 16)
     return small_hash
 
   def add_node(self, node):
     self.nodes.add(node)
     for i in range(self.replica_count):
-      replica_key = "%s:%d" % (node, i)
+      if self.hash_type == 'fnv1a_ch':
+        replica_key = "%d-%s" % (i, node[1])
+      else:
+        replica_key = "%s:%d" % (node, i)
       position = self.compute_ring_position(replica_key)
       while position in [r[0] for r in self.ring]:
         position = position + 1

--- a/lib/carbon/tests/test_hashing.py
+++ b/lib/carbon/tests/test_hashing.py
@@ -169,14 +169,18 @@ class FNVHashIntegrityTest(unittest.TestCase):
 class ConsistentHashRingTestFNV1A(unittest.TestCase):
 
     def test_chr_compute_ring_position_fnv1a(self):
-        hosts = [("127.0.0.1", "ba603c36342304ed77953f84ac4d357b"),("127.0.0.2", "5dd63865534f84899c6e5594dba6749a"),
-        ("127.0.0.3", "866a18b81f2dc4649517a1df13e26f28")]
+        hosts = [("127.0.0.1", "ba603c36342304ed77953f84ac4d357b"),
+                 ("127.0.0.2", "5dd63865534f84899c6e5594dba6749a"),
+                 ("127.0.0.3", "866a18b81f2dc4649517a1df13e26f28")]
         hashring = ConsistentHashRing(hosts, hash_type='fnv1a_ch')
-        self.assertEqual(hashring.compute_ring_position('hosts.worker1.cpu'), 59573)
-        self.assertEqual(hashring.compute_ring_position('hosts.worker2.cpu'), 35749)
+        self.assertEqual(hashring.compute_ring_position('hosts.worker1.cpu'),
+                         59573)
+        self.assertEqual(hashring.compute_ring_position('hosts.worker2.cpu'),
+                         35749)
 
     def test_chr_get_node_fnv1a(self):
-        hosts = [("127.0.0.1", "ba603c36342304ed77953f84ac4d357b"), ("127.0.0.2", "5dd63865534f84899c6e5594dba6749a"),
+        hosts = [("127.0.0.1", "ba603c36342304ed77953f84ac4d357b"),
+                 ("127.0.0.2", "5dd63865534f84899c6e5594dba6749a"),
                  ("127.0.0.3", "866a18b81f2dc4649517a1df13e26f28")]
         hashring = ConsistentHashRing(hosts, hash_type='fnv1a_ch')
         self.assertEqual(hashring.get_node('hosts.worker1.cpu'),

--- a/lib/carbon/tests/test_hashing.py
+++ b/lib/carbon/tests/test_hashing.py
@@ -164,3 +164,22 @@ class FNVHashIntegrityTest(unittest.TestCase):
         self.assertEqual(
                 len([n[0] for n in ring.ring]),
             len(set([n[0] for n in ring.ring])))
+
+
+class ConsistentHashRingTestFNV1A(unittest.TestCase):
+
+    def test_chr_compute_ring_position_fnv1a(self):
+        hosts = [("127.0.0.1", "ba603c36342304ed77953f84ac4d357b"),("127.0.0.2", "5dd63865534f84899c6e5594dba6749a"),
+        ("127.0.0.3", "866a18b81f2dc4649517a1df13e26f28")]
+        hashring = ConsistentHashRing(hosts, hash_type='fnv1a_ch')
+        self.assertEqual(hashring.compute_ring_position('hosts.worker1.cpu'), 59573)
+        self.assertEqual(hashring.compute_ring_position('hosts.worker2.cpu'), 35749)
+
+    def test_chr_get_node_fnv1a(self):
+        hosts = [("127.0.0.1", "ba603c36342304ed77953f84ac4d357b"), ("127.0.0.2", "5dd63865534f84899c6e5594dba6749a"),
+                 ("127.0.0.3", "866a18b81f2dc4649517a1df13e26f28")]
+        hashring = ConsistentHashRing(hosts, hash_type='fnv1a_ch')
+        self.assertEqual(hashring.get_node('hosts.worker1.cpu'),
+                         ('127.0.0.1', 'ba603c36342304ed77953f84ac4d357b'))
+        self.assertEqual(hashring.get_node('hosts.worker2.cpu'),
+                         ('127.0.0.3', '866a18b81f2dc4649517a1df13e26f28'))

--- a/lib/carbon/tests/test_hashing.py
+++ b/lib/carbon/tests/test_hashing.py
@@ -82,3 +82,85 @@ class HashIntegrityTest(unittest.TestCase):
         self.assertEqual(
                 len([n[0] for n in ring.ring]),
             len(set([n[0] for n in ring.ring])))
+
+
+class FNVHashIntegrityTest(unittest.TestCase):
+
+    def test_2_node_positional_itegrity(self):
+        """Make a cluster, verify we don't have positional collisions"""
+        ring = ConsistentHashRing([], hash_type='fnv1a_ch')
+        for n in range(2):
+            ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
+        self.assertEqual(
+                len([n[0] for n in ring.ring]),
+            len(set([n[0] for n in ring.ring])))
+
+
+    def test_3_node_positional_itegrity(self):
+        """Make a cluster, verify we don't have positional collisions"""
+        ring = ConsistentHashRing([], hash_type='fnv1a_ch')
+        for n in range(3):
+            ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
+        self.assertEqual(
+                len([n[0] for n in ring.ring]),
+            len(set([n[0] for n in ring.ring])))
+
+
+    def test_4_node_positional_itegrity(self):
+        """Make a cluster, verify we don't have positional collisions"""
+        ring = ConsistentHashRing([], hash_type='fnv1a_ch')
+        for n in range(4):
+            ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
+        self.assertEqual(
+                len([n[0] for n in ring.ring]),
+            len(set([n[0] for n in ring.ring])))
+
+
+    def test_5_node_positional_itegrity(self):
+        """Make a cluster, verify we don't have positional collisions"""
+        ring = ConsistentHashRing([], hash_type='fnv1a_ch')
+        for n in range(5):
+            ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
+        self.assertEqual(
+                len([n[0] for n in ring.ring]),
+            len(set([n[0] for n in ring.ring])))
+
+
+    def test_6_node_positional_itegrity(self):
+        """Make a cluster, verify we don't have positional collisions"""
+        ring = ConsistentHashRing([], hash_type='fnv1a_ch')
+        for n in range(6):
+            ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
+        self.assertEqual(
+                len([n[0] for n in ring.ring]),
+            len(set([n[0] for n in ring.ring])))
+
+
+    def test_7_node_positional_itegrity(self):
+        """Make a cluster, verify we don't have positional collisions"""
+        ring = ConsistentHashRing([], hash_type='fnv1a_ch')
+        for n in range(7):
+            ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
+        self.assertEqual(
+                len([n[0] for n in ring.ring]),
+            len(set([n[0] for n in ring.ring])))
+
+
+    def test_8_node_positional_itegrity(self):
+        """Make a cluster, verify we don't have positional collisions"""
+        ring = ConsistentHashRing([], hash_type='fnv1a_ch')
+        for n in range(8):
+            ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
+        self.assertEqual(
+                len([n[0] for n in ring.ring]),
+            len(set([n[0] for n in ring.ring])))
+
+
+    def test_9_node_positional_itegrity(self):
+        """Make a cluster, verify we don't have positional collisions"""
+        ring = ConsistentHashRing([], hash_type='fnv1a_ch')
+        for n in range(9):
+            ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
+        self.assertEqual(
+                len([n[0] for n in ring.ring]),
+            len(set([n[0] for n in ring.ring])))


### PR DESCRIPTION
Backporting [fnv1a_hash ring from graphite-web](https://github.com/graphite-project/graphite-web/pull/1723) to carbon master.

It's not a full support of fnv1a hashing in carbon, only hashing part. I want to use that in carbonate for a rebalancing of fnv clusters - https://github.com/graphite-project/carbonate/pull/83

Completely not sure about Python 3.x - my tests show that fnv1a function accepts Unicode and non-Unicode strings with same results but that need to be tested. How it looks like, @piotr1212 ?
