### PR TITLE
compute_ring_position - invalid literal error

### DIFF
--- a/lib/carbon/hashing.py
+++ b/lib/carbon/hashing.py
@@ -39,8 +39,7 @@ class ConsistentHashRing:
         big_hash = '{:x}'.format(int(fnv32a(key)))
       else:
         big_hash = '{:x}'.format(int(fnv32a(str(key))))
-      big_hash_length = len(big_hash)
-      if big_hash_length > 4:
+      if len(big_hash) > 4:
           small_hash = int(big_hash[:4], 16) ^ int(big_hash[4:], 16)
       else:
           small_hash = int(big_hash, 16) ^ int(big_hash[::-1], 16)

--- a/lib/carbon/hashing.py
+++ b/lib/carbon/hashing.py
@@ -39,7 +39,11 @@ class ConsistentHashRing:
         big_hash = '{:x}'.format(int(fnv32a(key)))
       else:
         big_hash = '{:x}'.format(int(fnv32a(str(key))))
-      small_hash = int(big_hash[:4], 16) ^ int(big_hash[4:], 16)
+      big_hash_length = len(big_hash)
+      if big_hash_length > 4:
+          small_hash = int(big_hash[:4], 16) ^ int(big_hash[4:], 16)
+      else:
+          small_hash = int(big_hash, 16) ^ int(big_hash[::-1], 16)
     else:
       if sys.version_info >= (3, 0):
         big_hash = md5(key.encode('utf-8')).hexdigest()

--- a/lib/carbon/hashing.py
+++ b/lib/carbon/hashing.py
@@ -42,7 +42,7 @@ class ConsistentHashRing:
       if len(big_hash) > 4:
           small_hash = int(big_hash[:4], 16) ^ int(big_hash[4:], 16)
       else:
-          small_hash = int(big_hash, 16) ^ int(big_hash[::-1], 16)
+          small_hash = int(big_hash, 16)
     else:
       if sys.version_info >= (3, 0):
         big_hash = md5(key.encode('utf-8')).hexdigest()

--- a/lib/carbon/tests/test_hashing.py
+++ b/lib/carbon/tests/test_hashing.py
@@ -187,3 +187,5 @@ class ConsistentHashRingTestFNV1A(unittest.TestCase):
                          ('127.0.0.1', 'ba603c36342304ed77953f84ac4d357b'))
         self.assertEqual(hashring.get_node('hosts.worker2.cpu'),
                          ('127.0.0.3', '866a18b81f2dc4649517a1df13e26f28'))
+        self.assertEqual(hashring.get_node('stats.checkout.cluster.padamski-wro.api.v1.payment-initialize.count'),
+                         ('127.0.0.3', '866a18b81f2dc4649517a1df13e26f28'))                     

--- a/lib/carbon/tests/test_hashing.py
+++ b/lib/carbon/tests/test_hashing.py
@@ -187,5 +187,6 @@ class ConsistentHashRingTestFNV1A(unittest.TestCase):
                          ('127.0.0.1', 'ba603c36342304ed77953f84ac4d357b'))
         self.assertEqual(hashring.get_node('hosts.worker2.cpu'),
                          ('127.0.0.3', '866a18b81f2dc4649517a1df13e26f28'))
-        self.assertEqual(hashring.get_node('stats.checkout.cluster.padamski-wro.api.v1.payment-initialize.count'),
-                         ('127.0.0.3', '866a18b81f2dc4649517a1df13e26f28'))                     
+        self.assertEqual(hashring.get_node(
+                        'stats.checkout.cluster.padamski-wro.api.v1.payment-initialize.count'),
+                        ('127.0.0.3', '866a18b81f2dc4649517a1df13e26f28'))


### PR DESCRIPTION
I was testing this part of code  against the real data sets - more than 100K metrics. 
and found that int(fnv32a(key)) can be really low int number for some keys 
and  cutting its hexadecimal equivalent to  [4:] breaks the function with this error: 

> File "/opt/graphite/lib/carbon/hashing.py", line , in compute_ring_position
    small_hash = int(big_hash[:4], 16) ^ int(big_hash[4:], 16)
ValueError: invalid literal for int() with base 16: ''

same happens when using pyhash so fnv32a in general seems to be working properly. 
I'm not sure if this code makes sense. Specially this part: 
`small_hash = int(big_hash, 16) ^ int(big_hash[::-1], 16)`
maybe we should just use: 
`small_hash = int(big_hash, 16)`
