### PR TITLE
fix listening on IPv6 interfaces

### DIFF
--- a/lib/carbon/protocols.py
+++ b/lib/carbon/protocols.py
@@ -45,11 +45,11 @@ class CarbonService(service.Service):
     def startService(self):
         # use socket creation from twisted to use the same options as before
         if hasattr(self.protocol, 'datagramReceived'):
-            tmp_port = udp.Port(None, None)
+            tmp_port = udp.Port(None, None, interface=self.interface)
         else:
-            tmp_port = tcp.Port(None, None)
+            tmp_port = tcp.Port(None, None, interface=self.interface)
         carbon_sock = tmp_port.createInternetSocket()
-        if hasattr(socket, "SO_REUSEPORT"):
+        if hasattr(socket, 'SO_REUSEPORT'):
             carbon_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
         carbon_sock.bind((self.interface, self.port))
 


### PR DESCRIPTION
Having e.g. `LINE_RECEIVER_INTERFACE = ::` in carbon.conf and trying to start carbon-cache with that, get following error:

```
GRAPHITE_ROOT=/srv/carbon /usr/bin/carbon-cache.py --config=/srv/carbon/conf/carbon.conf --debug start
Starting carbon-cache (instance a)
15/09/2017 18:31:52 :: [console] Using sorted write strategy for cache
15/09/2017 18:31:52 :: [console] Enabling Whisper fallocate support
15/09/2017 18:31:52 :: [console] Enabling Whisper file locking
15/09/2017 18:31:52 :: [console] twistd 17.5.0 (/usr/bin/python 3.6.2) starting up.
15/09/2017 18:31:52 :: [console] reactor class: twisted.internet.epollreactor.EPollReactor.
15/09/2017 18:31:52 :: [console] ServerFactory starting on 7002
15/09/2017 18:31:52 :: [console] Starting factory <twisted.internet.protocol.ServerFactory object at 0x7f77cce278>
15/09/2017 18:31:52 :: [console] Installing SIG_IGN for SIGHUP
15/09/2017 18:31:52 :: [console] Traceback (most recent call last):
15/09/2017 18:31:52 :: [console]   File "/usr/bin/carbon-cache.py", line 32, in <module>
15/09/2017 18:31:52 :: [console]     run_twistd_plugin(__file__)
15/09/2017 18:31:52 :: [console]   File "/usr/lib/python3.6/site-packages/carbon/util.py", line 107, in run_twistd_plugin
15/09/2017 18:31:52 :: [console]     runApp(config)
15/09/2017 18:31:52 :: [console]   File "/usr/lib/python3.6/site-packages/twisted/scripts/twistd.py", line 25, in runApp
15/09/2017 18:31:52 :: [console]     _SomeApplicationRunner(config).run()
15/09/2017 18:31:52 :: [console]   File "/usr/lib/python3.6/site-packages/twisted/application/app.py", line 384, in run
15/09/2017 18:31:52 :: [console]     self.postApplication()
15/09/2017 18:31:52 :: [console]   File "/usr/lib/python3.6/site-packages/twisted/scripts/_twistd_unix.py", line 248, in postApplication
15/09/2017 18:31:52 :: [console]     self.startApplication(self.application)
15/09/2017 18:31:52 :: [console]   File "/usr/lib/python3.6/site-packages/twisted/scripts/_twistd_unix.py", line 444, in startApplication
15/09/2017 18:31:52 :: [console]     app.startApplication(application, not self.config['no_save'])
15/09/2017 18:31:52 :: [console]   File "/usr/lib/python3.6/site-packages/twisted/application/app.py", line 678, in startApplication
15/09/2017 18:31:52 :: [console]     service.IService(application).startService()
15/09/2017 18:31:52 :: [console]   File "/usr/lib/python3.6/site-packages/twisted/application/service.py", line 284, in startService
15/09/2017 18:31:52 :: [console]     service.startService()
15/09/2017 18:31:52 :: [console]   File "/usr/lib/python3.6/site-packages/twisted/application/service.py", line 284, in startService
15/09/2017 18:31:52 :: [console]     service.startService()
15/09/2017 18:31:52 :: [console]   File "/usr/lib/python3.6/site-packages/carbon/protocols.py", line 54, in startService
15/09/2017 18:31:52 :: [console]     carbon_sock.bind((self.interface, self.port))
15/09/2017 18:31:52 :: [console] socket.gaierror: [Errno -9] Address family for hostname not supported
```

(there's python3 in there, but it doesn't seem to be related to that - see below)

Cause seem to be `tmp_port = tcp.Port(None, None)` line, due to this code in twisted.internet.tcp.Port init:
https://github.com/twisted/twisted/blob/73134d27/src/twisted/internet/tcp.py#L910-L923
(udp.Port has similar code)

Note that addressFamily there defaults to IPv4 unless init detects that passed interface value is IPv6.

When `tmp_port.createInternetSocket()` gets called later, it creates AF_INET (IPv4) socket here (BasePort):
https://github.com/twisted/twisted/blob/73134d27/src/twisted/internet/base.py#L1158-L1162

Which raises exception later on bind() with IPv6 interface/address.

Possible fixes:

- Detect (or set explicitly in the config) addressFamily value and set it as e.g. `tmp_port.addressFamily = family`.

- Let twisted handle family detection and by simply passing interface= there.

Latter one is used here, as Port.interface seem to only get used on Port.startListening (where it does bind()), which is not used for tmp_port instance.

Possible issues: compatibility - didn't check if passing interface= there is compatible with earliest twisted that graphite supports.

Somewhat surprised that it doesn't seem to be reported already - maybe only happens with newer twisted? Or is it just me?

Thanks!