### PR TITLE
Fix lint issues, run lint checks in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ python:
     - pypy
 
 install:
-    - pip install -r requirements.txt
-    - python setup.py install --prefix=$VIRTUAL_ENV --install-lib=$VIRTUAL_ENV/lib/python$TRAVIS_PYTHON_VERSION/site-packages
     - pip install tox-travis
 
 script:

--- a/lib/carbon/aggregator/buffers.py
+++ b/lib/carbon/aggregator/buffers.py
@@ -59,9 +59,10 @@ class MetricBuffer:
     self.configured = True
 
   def compute_value(self):
-    now = int( time.time() )
+    now = int(time.time())
     current_interval = now - (now % self.aggregation_frequency)
-    age_threshold = current_interval - (settings['MAX_AGGREGATION_INTERVALS'] * self.aggregation_frequency)
+    age_threshold = current_interval - (
+      settings['MAX_AGGREGATION_INTERVALS'] * self.aggregation_frequency)
 
     for buffer in list(self.interval_buffers.values()):
       if buffer.active:
@@ -96,7 +97,7 @@ class IntervalBuffer:
     self.active = True
 
   def input(self, datapoint):
-    self.values.append( datapoint[1] )
+    self.values.append(datapoint[1])
     self.active = True
 
   def mark_inactive(self):
@@ -107,4 +108,4 @@ class IntervalBuffer:
 BufferManager = BufferManager()
 
 # Avoid import circularity
-from carbon import state
+from carbon import state  # NOQA

--- a/lib/carbon/aggregator/buffers.py
+++ b/lib/carbon/aggregator/buffers.py
@@ -4,7 +4,7 @@ from carbon.conf import settings
 from carbon import log
 
 
-class BufferManager:
+class _BufferManager:
   def __init__(self):
     self.buffers = {}
 
@@ -105,7 +105,7 @@ class IntervalBuffer:
 
 
 # Shared importable singleton
-BufferManager = BufferManager()
+BufferManager = _BufferManager()
 
 # Avoid import circularity
 from carbon import state  # NOQA

--- a/lib/carbon/aggregator/processor.py
+++ b/lib/carbon/aggregator/processor.py
@@ -38,5 +38,6 @@ class AggregationProcessor(Processor):
 
     if settings.FORWARD_ALL and metric not in aggregate_metrics:
       if settings.LOG_AGGREGATOR_MISSES and len(aggregate_metrics) == 0:
-        log.msg("Couldn't match metric %s with any aggregation rule. Passing on un-aggregated." % metric)
+        log.msg(
+          "Couldn't match metric %s with any aggregation rule. Passing on un-aggregated." % metric)
       yield (metric, datapoint)

--- a/lib/carbon/aggregator/rules.py
+++ b/lib/carbon/aggregator/rules.py
@@ -1,4 +1,3 @@
-import time
 import re
 
 from os.path import exists, getmtime
@@ -71,7 +70,7 @@ class RuleManager(object):
       left_side, right_side = line.split('=', 1)
       output_pattern, frequency = left_side.split()
       method, input_pattern = right_side.split()
-      frequency = int( frequency.lstrip('(').rstrip(')') )
+      frequency = int(frequency.lstrip('(').rstrip(')'))
       return AggregationRule(input_pattern, output_pattern, method, frequency)
 
     except ValueError:
@@ -125,8 +124,8 @@ class AggregationRule(object):
         i = input_part.find('<<')
         j = input_part.find('>>')
         pre = input_part[:i]
-        post = input_part[j+2:]
-        field_name = input_part[i+2:j]
+        post = input_part[j + 2:]
+        field_name = input_part[i + 2:j]
         regex_part = '%s(?P<%s>.+)%s' % (pre, field_name, post)
 
       else:
@@ -134,8 +133,8 @@ class AggregationRule(object):
         j = input_part.find('>')
         if i > -1 and j > i:
           pre = input_part[:i]
-          post = input_part[j+1:]
-          field_name = input_part[i+1:j]
+          post = input_part[j + 1:]
+          field_name = input_part[i + 1:j]
           regex_part = '%s(?P<%s>[^.]+)%s' % (pre, field_name, post)
         elif input_part == '*':
           regex_part = '[^.]+'
@@ -153,18 +152,19 @@ class AggregationRule(object):
 
 def avg(values):
   if values:
-    return float( sum(values) ) / len(values)
+    return float(sum(values)) / len(values)
+
 
 def count(values):
   if values:
     return len(values)
 
 AGGREGATION_METHODS = {
-  'sum'   : sum,
-  'avg'   : avg,
-  'min'   : min,
-  'max'   : max,
-  'count' : count
+  'sum': sum,
+  'avg': avg,
+  'min': min,
+  'max': max,
+  'count': count
 }
 
 # Importable singleton

--- a/lib/carbon/amqp_listener.py
+++ b/lib/carbon/amqp_listener.py
@@ -32,10 +32,6 @@ This program can be started standalone for testing or using carbon-cache.py
 """
 import sys
 
-# txamqp is currently not ported to py3
-if sys.version_info >= (3, 0):
-    raise ImportError
-
 import os
 import socket
 from optparse import OptionParser
@@ -55,10 +51,10 @@ except ImportError:
     LIB_DIR = os.path.dirname(os.path.dirname(__file__))
     sys.path.insert(0, LIB_DIR)
 
-import carbon.protocols #satisfy import order requirements
+import carbon.protocols  # NOQA satisfy import order requirements
 from carbon.protocols import CarbonServerProtocol
 from carbon.conf import settings
-from carbon import log, events, instrumentation
+from carbon import log, events
 
 
 HOSTNAME = socket.gethostname().split('.')[0]
@@ -122,13 +118,14 @@ class AMQPGraphiteProtocol(AMQClient):
 
         # bind each configured metric pattern
         for bind_pattern in settings.BIND_PATTERNS:
-            log.listener("binding exchange '%s' to queue '%s' with pattern %s" \
+            log.listener("binding exchange '%s' to queue '%s' with pattern %s"
                          % (exchange, my_queue, bind_pattern))
             yield chan.queue_bind(exchange=exchange, queue=my_queue,
                                   routing_key=bind_pattern)
 
         yield chan.basic_consume(queue=my_queue, no_ack=True,
                                  consumer_tag=self.consumer_tag)
+
     @inlineCallbacks
     def receive_loop(self):
         queue = yield self.queue(self.consumer_tag)
@@ -154,7 +151,7 @@ class AMQPGraphiteProtocol(AMQClient):
                     metric, value, timestamp = line.split()
                 else:
                     value, timestamp = line.split()
-                datapoint = ( float(timestamp), float(value) )
+                datapoint = (float(timestamp), float(value))
                 if datapoint[1] != datapoint[1]:  # filter out NaN values
                     continue
             except ValueError:
@@ -252,7 +249,6 @@ def main():
                       default=False, action="store_true")
 
     (options, args) = parser.parse_args()
-
 
     startReceiver(options.host, options.port, options.username,
                   options.password, vhost=options.vhost,

--- a/lib/carbon/amqp_listener.py
+++ b/lib/carbon/amqp_listener.py
@@ -40,9 +40,14 @@ from twisted.internet.defer import inlineCallbacks
 from twisted.internet import reactor
 from twisted.internet.protocol import ReconnectingClientFactory
 from twisted.application.internet import TCPClient
-from txamqp.protocol import AMQClient
-from txamqp.client import TwistedDelegate
-import txamqp.spec
+
+# txamqp is currently not ported to py3
+try:
+  from txamqp.protocol import AMQClient
+  from txamqp.client import TwistedDelegate
+  import txamqp.spec
+except:
+  raise ImportError
 
 try:
     import carbon

--- a/lib/carbon/amqp_publisher.py
+++ b/lib/carbon/amqp_publisher.py
@@ -21,7 +21,7 @@ import time
 from optparse import OptionParser
 
 from twisted.internet.defer import inlineCallbacks
-from twisted.internet import reactor, task
+from twisted.internet import reactor
 from twisted.internet.protocol import ClientCreator
 from txamqp.protocol import AMQClient
 from txamqp.client import TwistedDelegate
@@ -54,7 +54,7 @@ def writeMetric(metric_path, value, timestamp, host, port, username, password,
     yield channel.exchange_declare(exchange=exchange, type="topic",
                                    durable=True, auto_delete=False)
 
-    message = Content( "%f %d" % (value, timestamp) )
+    message = Content("%f %d" % (value, timestamp))
     message["delivery mode"] = 2
 
     channel.basic_publish(exchange=exchange, content=message, routing_key=metric_path)

--- a/lib/carbon/cache.py
+++ b/lib/carbon/cache.py
@@ -245,4 +245,4 @@ def MetricCache():
 
 
 # Avoid import circularities
-from carbon import state
+from carbon import state  # NOQA

--- a/lib/carbon/cache.py
+++ b/lib/carbon/cache.py
@@ -81,7 +81,7 @@ class MaxStrategy(DrainStrategy):
   that infrequently or irregularly updated metrics may not be written
   until shutdown """
   def choose_item(self):
-    metric_name, size = max(self.cache.items(), key=lambda x: len(itemgetter(1)(x)))
+    metric_name, _ = max(self.cache.items(), key=lambda x: len(itemgetter(1)(x)))
     return metric_name
 
 

--- a/lib/carbon/carbon_pb2.py
+++ b/lib/carbon/carbon_pb2.py
@@ -2,29 +2,28 @@
 # source: carbon.proto
 
 import sys
-_b=sys.version_info[0]<3 and (lambda x:x) or (lambda x:x.encode('latin1'))
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
-from google.protobuf import descriptor_pb2
 # @@protoc_insertion_point(imports)
+
 
 _sym_db = _symbol_database.Default()
 
-
-
+_b = sys.version_info[0] < 3 and (lambda x: x) or (lambda x: x.encode('latin1'))
 
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='carbon.proto',
   package='carbon',
   syntax='proto3',
-  serialized_pb=_b('\n\x0c\x63\x61rbon.proto\x12\x06\x63\x61rbon\")\n\x05Point\x12\x11\n\ttimestamp\x18\x01 \x01(\r\x12\r\n\x05value\x18\x02 \x01(\x01\"7\n\x06Metric\x12\x0e\n\x06metric\x18\x01 \x01(\t\x12\x1d\n\x06points\x18\x02 \x03(\x0b\x32\r.carbon.Point\"*\n\x07Payload\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.carbon.Metricb\x06proto3')
+  serialized_pb=_b('\n\x0c\x63\x61rbon.proto\x12\x06\x63\x61rbon\")\n\x05Point\x12\x11\n\ttimestamp'
+                   '\x18\x01 \x01(\r\x12\r\n\x05value\x18\x02 \x01(\x01\"7\n\x06Metric\x12\x0e\n'
+                   '\x06metric\x18\x01 \x01(\t\x12\x1d\n\x06points\x18\x02 \x03(\x0b\x32\r.carbon.'
+                   'Point\"*\n\x07Payload\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.carbon.'
+                   'Metricb\x06proto3')
 )
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
-
-
-
 
 _POINT = _descriptor.Descriptor(
   name='Point',
@@ -139,25 +138,24 @@ DESCRIPTOR.message_types_by_name['Metric'] = _METRIC
 DESCRIPTOR.message_types_by_name['Payload'] = _PAYLOAD
 
 Point = _reflection.GeneratedProtocolMessageType('Point', (_message.Message,), dict(
-  DESCRIPTOR = _POINT,
-  __module__ = 'carbon_pb2'
+  DESCRIPTOR=_POINT,
+  __module__='carbon_pb2'
   # @@protoc_insertion_point(class_scope:carbon.Point)
-  ))
+))
 _sym_db.RegisterMessage(Point)
 
 Metric = _reflection.GeneratedProtocolMessageType('Metric', (_message.Message,), dict(
-  DESCRIPTOR = _METRIC,
-  __module__ = 'carbon_pb2'
+  DESCRIPTOR=_METRIC,
+  __module__='carbon_pb2'
   # @@protoc_insertion_point(class_scope:carbon.Metric)
-  ))
+))
 _sym_db.RegisterMessage(Metric)
 
 Payload = _reflection.GeneratedProtocolMessageType('Payload', (_message.Message,), dict(
-  DESCRIPTOR = _PAYLOAD,
-  __module__ = 'carbon_pb2'
+  DESCRIPTOR=_PAYLOAD,
+  __module__='carbon_pb2'
   # @@protoc_insertion_point(class_scope:carbon.Payload)
-  ))
+))
 _sym_db.RegisterMessage(Payload)
-
 
 # @@protoc_insertion_point(module_scope)

--- a/lib/carbon/client.py
+++ b/lib/carbon/client.py
@@ -116,13 +116,11 @@ class CarbonClientProtocol(object):
           instrumentation.prior_stats.get('metricsReceived', 0)))
 
     self.sendDatapointsNow(self.factory.takeSomeFromQueue())
-    if (self.factory.queueFull.called and
-        queueSize < SEND_QUEUE_LOW_WATERMARK):
+    if (self.factory.queueFull.called and queueSize < SEND_QUEUE_LOW_WATERMARK):
       if not self.factory.queueHasSpace.called:
         self.factory.queueHasSpace.callback(queueSize)
     if self.factory.hasQueuedDatapoints():
       self.factory.scheduleSend()
-
 
   def connectionQualityMonitor(self):
     """Checks to see if the connection for this factory appears to
@@ -137,7 +135,6 @@ class CarbonClientProtocol(object):
     True means that the total received is less than settings.MIN_RESET_STAT_FLOW
 
     False means that quality is bad
-
     """
     destination_sent = float(instrumentation.prior_stats.get(self.sent, 0))
     total_received = float(instrumentation.prior_stats.get('metricsReceived', 0))

--- a/lib/carbon/client.py
+++ b/lib/carbon/client.py
@@ -253,7 +253,7 @@ class CarbonClientFactory(with_metaclass(PluginRegistrar, ReconnectingClientFact
     queue.
     """
     def yield_max_datapoints():
-      for count in range(settings.MAX_DATAPOINTS_PER_MESSAGE):
+      for _ in range(settings.MAX_DATAPOINTS_PER_MESSAGE):
         try:
           yield self.queue.popleft()
         except IndexError:
@@ -467,8 +467,6 @@ class CarbonClientManager(Service):
     state.events.resumeReceivingMetrics.addHandler(fake_factory.reinjectDatapoints)
 
   def createFactory(self, destination):
-    from carbon.conf import settings
-
     factory_name = settings["DESTINATION_PROTOCOL"]
     factory_class = CarbonClientFactory.plugins.get(factory_name)
 

--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -238,12 +238,14 @@ class CarbonCacheOptions(usage.Options):
         settings["program"] = program
 
         # Normalize and expand paths
-        settings["STORAGE_DIR"] = os.path.normpath(os.path.expanduser(settings["STORAGE_DIR"]))
-        settings["LOCAL_DATA_DIR"] = os.path.normpath(os.path.expanduser(settings["LOCAL_DATA_DIR"]))
-        settings["WHITELISTS_DIR"] = os.path.normpath(os.path.expanduser(settings["WHITELISTS_DIR"]))
-        settings["PID_DIR"] = os.path.normpath(os.path.expanduser(settings["PID_DIR"]))
-        settings["LOG_DIR"] = os.path.normpath(os.path.expanduser(settings["LOG_DIR"]))
-        settings["pidfile"] = os.path.normpath(os.path.expanduser(settings["pidfile"]))
+        def cleanpath(path):
+          return os.path.normpath(os.path.expanduser(path))
+        settings["STORAGE_DIR"] = cleanpath(settings["STORAGE_DIR"])
+        settings["LOCAL_DATA_DIR"] = cleanpath(settings["LOCAL_DATA_DIR"])
+        settings["WHITELISTS_DIR"] = cleanpath(settings["WHITELISTS_DIR"])
+        settings["PID_DIR"] = cleanpath(settings["PID_DIR"])
+        settings["LOG_DIR"] = cleanpath(settings["LOG_DIR"])
+        settings["pidfile"] = cleanpath(settings["pidfile"])
 
         # Set process uid/gid by changing the parent config, if a user was
         # provided in the configuration file.
@@ -277,7 +279,7 @@ class CarbonCacheOptions(usage.Options):
 
         settings.CACHE_SIZE_LOW_WATERMARK = settings.MAX_CACHE_SIZE * 0.95
 
-        if not "action" in self:
+        if "action" not in self:
             self["action"] = "start"
         self.handleAction()
 
@@ -368,7 +370,7 @@ class CarbonCacheOptions(usage.Options):
 
             if _process_alive(pid):
                 print("%s (instance %s) is running with pid %d" %
-                       (program, instance, pid))
+                      (program, instance, pid))
                 raise SystemExit(0)
             else:
                 print("%s (instance %s) is not running" % (program, instance))
@@ -388,7 +390,7 @@ class CarbonCacheOptions(usage.Options):
                     raise SystemExit(1)
                 if _process_alive(pid):
                     print("%s (instance %s) is already running with pid %d" %
-                           (program, instance, pid))
+                          (program, instance, pid))
                     raise SystemExit(1)
                 else:
                     print("Removing stale pidfile %s" % pidfile)
@@ -401,13 +403,11 @@ class CarbonCacheOptions(usage.Options):
                 if not os.path.exists(settings["PID_DIR"]):
                     try:
                         os.makedirs(settings["PID_DIR"])
-                    except OSError as exc: # Python >2.5
+                    except OSError as exc:  # Python >2.5
                         if exc.errno == errno.EEXIST and os.path.isdir(settings["PID_DIR"]):
                            pass
                         else:
                            raise
-
-
 
             print("Starting %s (instance %s)" % (program, instance))
 
@@ -422,7 +422,7 @@ class CarbonAggregatorOptions(CarbonCacheOptions):
     optParameters = [
         ["rules", "", None, "Use the given aggregation rules file."],
         ["rewrite-rules", "", None, "Use the given rewrite rules file."],
-        ] + CarbonCacheOptions.optParameters
+    ] + CarbonCacheOptions.optParameters
 
     def postOptions(self):
         CarbonCacheOptions.postOptions(self)
@@ -441,7 +441,7 @@ class CarbonRelayOptions(CarbonCacheOptions):
     optParameters = [
         ["rules", "", None, "Use the given relay rules file."],
         ["aggregation-rules", "", None, "Use the given aggregation rules file."],
-        ] + CarbonCacheOptions.optParameters
+    ] + CarbonCacheOptions.optParameters
 
     def postOptions(self):
         CarbonCacheOptions.postOptions(self)
@@ -562,7 +562,7 @@ def read_config(program, options, **kwargs):
         graphite_root = os.environ.get('GRAPHITE_ROOT')
     if graphite_root is None:
         raise CarbonConfigException("Either ROOT_DIR or GRAPHITE_ROOT "
-                         "needs to be provided.")
+                                    "needs to be provided.")
 
     # Default config directory to root-relative, unless overriden by the
     # 'GRAPHITE_CONF_DIR' environment variable.
@@ -594,8 +594,6 @@ def read_config(program, options, **kwargs):
         settings.setdefault(
             "WHITELISTS_DIR", join(settings["STORAGE_DIR"], "lists"))
 
-
-
     # Read configuration options from program-specific section.
     section = program[len("carbon-"):]
     config = options["config"]
@@ -615,15 +613,13 @@ def read_config(program, options, **kwargs):
                           "%s:%s" % (section, options["instance"]))
         settings["pidfile"] = (
             options["pidfile"] or
-            join(settings["PID_DIR"], "%s-%s.pid" %
-                 (program, options["instance"])))
-        settings["LOG_DIR"] = (options["logdir"] or
-                              join(settings["LOG_DIR"],
-                                "%s-%s" % (program, options["instance"])))
+            join(settings["PID_DIR"], "%s-%s.pid" % (program, options["instance"])))
+        settings["LOG_DIR"] = (
+            options["logdir"] or
+            join(settings["LOG_DIR"], "%s-%s" % (program, options["instance"])))
     else:
         settings["pidfile"] = (
-            options["pidfile"] or
-            join(settings["PID_DIR"], '%s.pid' % program))
+            options["pidfile"] or join(settings["PID_DIR"], '%s.pid' % program))
         settings["LOG_DIR"] = (options["logdir"] or settings["LOG_DIR"])
 
     update_STORAGE_DIR_deps()

--- a/lib/carbon/events.py
+++ b/lib/carbon/events.py
@@ -1,6 +1,3 @@
-from twisted.python.failure import Failure
-
-
 class Event:
   def __init__(self, name):
     self.name = name
@@ -19,7 +16,8 @@ class Event:
       try:
         handler(*args, **kwargs)
       except Exception:
-        log.err(None, "Exception in %s event handler: args=%s kwargs=%s" % (self.name, args, kwargs))
+        log.err(
+          None, "Exception in %s event handler: args=%s kwargs=%s" % (self.name, args, kwargs))
 
 
 metricReceived = Event('metricReceived')
@@ -30,7 +28,8 @@ pauseReceivingMetrics = Event('pauseReceivingMetrics')
 resumeReceivingMetrics = Event('resumeReceivingMetrics')
 
 # Default handlers
-metricReceived.addHandler(lambda metric, datapoint: state.instrumentation.increment('metricsReceived'))
+metricReceived.addHandler(
+  lambda metric, datapoint: state.instrumentation.increment('metricsReceived'))
 
 
 cacheFull.addHandler(lambda: state.instrumentation.increment('cache.overflow'))
@@ -42,4 +41,4 @@ resumeReceivingMetrics.addHandler(lambda: setattr(state, 'metricReceiversPaused'
 
 
 # Avoid import circularities
-from carbon import log, state
+from carbon import log, state  # NOQA

--- a/lib/carbon/hashing.py
+++ b/lib/carbon/hashing.py
@@ -8,6 +8,7 @@ import sys
 try:
   import pyhash
   hasher = pyhash.fnv1a_32()
+
   def fnv32a(string, seed=0x811c9dc5):
     return hasher(string, seed=seed)
 except ImportError:
@@ -23,6 +24,7 @@ except ImportError:
       hval = hval ^ ord(s)
       hval = (hval * fnv_32_prime) % uint32_max
     return hval
+
 
 class ConsistentHashRing:
   def __init__(self, nodes, replica_count=100, hash_type='carbon_ch'):

--- a/lib/carbon/instrumentation.py
+++ b/lib/carbon/instrumentation.py
@@ -21,7 +21,7 @@ lastUsageTime = time.time()
 
 # TODO(chrismd) refactor the graphite metrics hierarchy to be cleaner,
 # more consistent, and make room for frontend metrics.
-#metric_prefix = "Graphite.backend.%(program)s.%(instance)s." % settings
+# metric_prefix = "Graphite.backend.%(program)s.%(instance)s." % settings
 
 
 def increment(stat, increase=1):
@@ -30,12 +30,14 @@ def increment(stat, increase=1):
   except KeyError:
     stats[stat] = increase
 
+
 def max(stat, newval):
   try:
     if stats[stat] < newval:
       stats[stat] = newval
   except KeyError:
     stats[stat] = newval
+
 
 def append(stat, value):
   try:
@@ -133,7 +135,7 @@ def recordMetrics():
   # shared relay stats for relays & aggregators
   if settings.program in ['carbon-aggregator', 'carbon-relay']:
     prefix = 'destinations.'
-    relay_stats =  [(k,v) for (k,v) in myStats.items() if k.startswith(prefix)]
+    relay_stats = [(k, v) for (k, v) in myStats.items() if k.startswith(prefix)]
     for stat_name, stat_value in relay_stats:
       record(stat_name, stat_value)
       # Preserve the count of sent metrics so that the ratio of
@@ -206,5 +208,5 @@ class InstrumentationService(Service):
 
 
 # Avoid import circularities
-from carbon import state, events, cache
-from carbon.aggregator.buffers import BufferManager
+from carbon import state, events, cache  # NOQA
+from carbon.aggregator.buffers import BufferManager  # NOQA

--- a/lib/carbon/log.py
+++ b/lib/carbon/log.py
@@ -78,7 +78,8 @@ class CarbonLogObserver(object):
   def __call__(self, event):
     return self.observer(event)
 
-  def stdout_observer(self, event):
+  @staticmethod
+  def stdout_observer(event):
     stdout.write(formatEvent(event, includeType=True) + '\n')
     stdout.flush()
 

--- a/lib/carbon/log.py
+++ b/lib/carbon/log.py
@@ -1,8 +1,8 @@
 import os
 import time
-from sys import stdout, stderr
+from sys import stdout
 from zope.interface import implementer
-from twisted.python.log import startLoggingWithObserver, textFromEventDict, msg, err, ILogObserver
+from twisted.python.log import startLoggingWithObserver, textFromEventDict, msg, err, ILogObserver  # NOQA
 from twisted.python.syslog import SyslogObserver
 from twisted.python.logfile import DailyLogFile
 
@@ -21,7 +21,7 @@ class CarbonLogFile(DailyLogFile):
     """
     openMode = self.defaultMode or 0o777
     self._file = os.fdopen(os.open(
-      self.path, os.O_CREAT|os.O_RDWR, openMode), 'r+', 1)
+      self.path, os.O_CREAT | os.O_RDWR, openMode), 'r+', 1)
     self.closed = False
     # Try our best to update permissions for files which already exist.
     if self.defaultMode:
@@ -48,8 +48,7 @@ class CarbonLogFile(DailyLogFile):
       else:
         path_stat = os.stat(self.path)
         fd_stat = os.fstat(self._file.fileno())
-        if not (path_stat.st_ino == fd_stat.st_ino 
-            and path_stat.st_dev == fd_stat.st_dev):
+        if not (path_stat.st_ino == fd_stat.st_ino and path_stat.st_dev == fd_stat.st_dev):
           self.reopen()
     DailyLogFile.write(self, data)
 
@@ -96,7 +95,7 @@ class CarbonLogObserver(object):
 
   # Default to stdout
   observer = stdout_observer
-   
+
 
 carbonLogObserver = CarbonLogObserver()
 

--- a/lib/carbon/management.py
+++ b/lib/carbon/management.py
@@ -1,6 +1,7 @@
 import traceback
 from carbon import log, state
 
+
 def getMetadata(metric, key):
   try:
     value = state.database.getMetadata(metric, key)

--- a/lib/carbon/protocols.py
+++ b/lib/carbon/protocols.py
@@ -3,7 +3,7 @@ import socket
 import sys
 
 from twisted.internet.protocol import ServerFactory, DatagramProtocol
-from twisted.application.internet import TCPServer, UDPServer
+# from twisted.application.internet import TCPServer, UDPServer
 from twisted.application import service
 from twisted.internet.error import ConnectionDone
 from twisted.internet import reactor, tcp, udp
@@ -124,10 +124,12 @@ class MetricReceiver(CarbonServerProtocol, TimeoutMixin):
   def connectionLost(self, reason):
     if reason.check(ConnectionDone):
       if settings.LOG_LISTENER_CONN_SUCCESS:
-        log.listener("%s connection with %s closed cleanly" % (self.__class__.__name__, self.peerName))
+        log.listener(
+          "%s connection with %s closed cleanly" % (self.__class__.__name__, self.peerName))
 
     else:
-      log.listener("%s connection with %s lost: %s" % (self.__class__.__name__, self.peerName, reason.value))
+      log.listener(
+        "%s connection with %s lost: %s" % (self.__class__.__name__, self.peerName, reason.value))
 
     state.connectedMetricReceiverProtocols.remove(self)
     if settings.USE_FLOW_CONTROL:
@@ -143,7 +145,8 @@ class MetricReceiver(CarbonServerProtocol, TimeoutMixin):
       return
     if datapoint[1] != datapoint[1]:  # filter out NaN values
       return
-    if int(datapoint[0]) == -1:  # use current time if none given: https://github.com/graphite-project/carbon/issues/54
+    # use current time if none given: https://github.com/graphite-project/carbon/issues/54
+    if int(datapoint[0]) == -1:
       datapoint = (time.time(), datapoint[1])
     res = settings.MIN_TIMESTAMP_RESOLUTION
     if res:
@@ -237,7 +240,7 @@ class MetricPickleReceiver(MetricReceiver, Int32StringReceiver):
 
 
 class CacheManagementHandler(Int32StringReceiver):
-  MAX_LENGTH = 1024 ** 3 # 1mb
+  MAX_LENGTH = 1024 ** 3  # 1mb
 
   def connectionMade(self):
     peer = self.transport.getPeer()
@@ -259,7 +262,9 @@ class CacheManagementHandler(Int32StringReceiver):
       datapoints = list(cache.get(metric, {}).items())
       result = dict(datapoints=datapoints)
       if settings.LOG_CACHE_HITS:
-        log.query('[%s] cache query for \"%s\" returned %d values' % (self.peerAddr, metric, len(datapoints)))
+        log.query('[%s] cache query for \"%s\" returned %d values' % (
+          self.peerAddr, metric, len(datapoints)
+        ))
       instrumentation.increment('cacheQueries')
 
     elif request['type'] == 'cache-query-bulk':
@@ -271,8 +276,11 @@ class CacheManagementHandler(Int32StringReceiver):
       result = dict(datapointsByMetric=datapointsByMetric)
 
       if settings.LOG_CACHE_HITS:
-        log.query('[%s] cache query bulk for \"%d\" metrics returned %d values' %
-            (self.peerAddr, len(metrics), sum([len(datapoints) for datapoints in datapointsByMetric.values()])))
+        log.query('[%s] cache query bulk for \"%d\" metrics returned %d values' % (
+          self.peerAddr,
+          len(metrics),
+          sum([len(datapoints) for datapoints in datapointsByMetric.values()])
+        ))
       instrumentation.increment('cacheBulkQueries')
       instrumentation.append('cacheBulkQuerySize', len(metrics))
 
@@ -290,5 +298,5 @@ class CacheManagementHandler(Int32StringReceiver):
 
 
 # Avoid import circularities
-from carbon.cache import MetricCache
-from carbon import instrumentation
+from carbon.cache import MetricCache  # NOQA
+from carbon import instrumentation  # NOQA

--- a/lib/carbon/regexlist.py
+++ b/lib/carbon/regexlist.py
@@ -1,4 +1,3 @@
-import time
 import re
 import os.path
 from carbon import log

--- a/lib/carbon/relayrules.py
+++ b/lib/carbon/relayrules.py
@@ -25,7 +25,7 @@ def loadRelayRules(path):
   for section in parser.sections():
     if not parser.has_option(section, 'destinations'):
       raise CarbonConfigException("Rules file %s section %s does not define a "
-                       "'destinations' list" % (path, section))
+                                  "'destinations' list" % (path, section))
 
     destination_strings = parser.get(section, 'destinations').split(',')
     destinations = parseDestinations(destination_strings)
@@ -33,14 +33,15 @@ def loadRelayRules(path):
     if parser.has_option(section, 'pattern'):
       if parser.has_option(section, 'default'):
         raise CarbonConfigException("Section %s contains both 'pattern' and "
-                        "'default'. You must use one or the other." % section)
+                                    "'default'. You must use one or the other." % section)
       pattern = parser.get(section, 'pattern')
       regex = re.compile(pattern, re.I)
 
       continue_matching = False
       if parser.has_option(section, 'continue'):
         continue_matching = parser.getboolean(section, 'continue')
-      rule = RelayRule(condition=regex.search, destinations=destinations, continue_matching=continue_matching)
+      rule = RelayRule(
+        condition=regex.search, destinations=destinations, continue_matching=continue_matching)
       rules.append(rule)
       continue
 
@@ -54,7 +55,7 @@ def loadRelayRules(path):
 
   if not defaultRule:
     raise CarbonConfigException("No default rule defined. You must specify exactly one "
-                    "rule with 'default = true' instead of a pattern.")
+                                "rule with 'default = true' instead of a pattern.")
 
   rules.append(defaultRule)
   return rules

--- a/lib/carbon/rewrite.py
+++ b/lib/carbon/rewrite.py
@@ -22,7 +22,7 @@ class RewriteProcessor(Processor):
     yield (metric, datapoint)
 
 
-class RewriteRuleManager:
+class _RewriteRuleManager:
   def __init__(self):
     self.rulesets = defaultdict(list)
     self.rules_file = None
@@ -94,4 +94,4 @@ class RewriteRule:
 
 
 # Ghetto singleton
-RewriteRuleManager = RewriteRuleManager()
+RewriteRuleManager = _RewriteRuleManager()

--- a/lib/carbon/service.py
+++ b/lib/carbon/service.py
@@ -156,7 +156,7 @@ def createRelayService(config):
 def setupReceivers(root_service, settings):
   from carbon.protocols import MetricReceiver
 
-  for plugin_name, plugin_class in MetricReceiver.plugins.items():
+  for _, plugin_class in MetricReceiver.plugins.items():
     plugin_class.build(root_service)
 
 
@@ -196,7 +196,6 @@ def setupWriterProcessor(root_service, settings):
   from carbon import cache  # NOQA Register CacheFeedingProcessor
   from carbon.protocols import CacheManagementHandler
   from carbon.writer import WriterService
-  from carbon import events
 
   factory = ServerFactory()
   factory.protocol = CacheManagementHandler

--- a/lib/carbon/service.py
+++ b/lib/carbon/service.py
@@ -15,7 +15,7 @@ limitations under the License."""
 from os.path import exists
 
 from twisted.application.service import MultiService
-from twisted.application.internet import TCPServer, TCPClient
+from twisted.application.internet import TCPServer
 from twisted.internet.protocol import ServerFactory
 from twisted.python.components import Componentized
 from twisted.python.log import ILogObserver
@@ -37,7 +37,7 @@ try:
 except ImportError:
   pass
 try:
-  import carbon.protobuf
+  import carbon.protobuf  # NOQA
 except ImportError as e:
   pass
 
@@ -96,7 +96,6 @@ def setupPipeline(pipeline, root_service, settings):
     if processor in ['relay', 'write']:
       state.pipeline_processors_generated.append(plugin_class(*args))
 
-
   events.metricReceived.addHandler(run_pipeline)
   events.metricGenerated.addHandler(run_pipeline_generated)
 
@@ -130,6 +129,7 @@ def createAggregatorService(config):
 
   return root_service
 
+
 def createAggregatorCacheService(config):
   from carbon.conf import settings
 
@@ -141,6 +141,7 @@ def createAggregatorCacheService(config):
   setupReceivers(root_service, settings)
 
   return root_service
+
 
 def createRelayService(config):
   from carbon.conf import settings
@@ -160,12 +161,13 @@ def setupReceivers(root_service, settings):
 
 
 def setupAggregatorProcessor(root_service, settings):
-  from carbon.aggregator.processor import AggregationProcessor  # Register the plugin class
+  from carbon.aggregator.processor import AggregationProcessor  # NOQA Register the plugin class
   from carbon.aggregator.rules import RuleManager
 
   aggregation_rules_path = settings["aggregation-rules"]
   if not exists(aggregation_rules_path):
-    raise CarbonConfigException("aggregation processor: file does not exist {0}".format(aggregation_rules_path))
+    raise CarbonConfigException(
+      "aggregation processor: file does not exist {0}".format(aggregation_rules_path))
   RuleManager.read_from(aggregation_rules_path)
 
 
@@ -191,7 +193,7 @@ def setupRelayProcessor(root_service, settings):
 
 
 def setupWriterProcessor(root_service, settings):
-  from carbon import cache  # Register CacheFeedingProcessor
+  from carbon import cache  # NOQA Register CacheFeedingProcessor
   from carbon.protocols import CacheManagementHandler
   from carbon.writer import WriterService
   from carbon import events

--- a/lib/carbon/service.py
+++ b/lib/carbon/service.py
@@ -38,7 +38,7 @@ except ImportError:
   pass
 try:
   import carbon.protobuf  # NOQA
-except ImportError as e:
+except ImportError:
   pass
 
 

--- a/lib/carbon/storage.py
+++ b/lib/carbon/storage.py
@@ -12,13 +12,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License."""
 
-import os
 import re
 
-from os.path import join, exists
+from os.path import join
 from carbon.conf import OrderedConfigParser, settings
 from carbon.exceptions import CarbonConfigException
-from carbon.util import pickle, parseRetentionDef
+from carbon.util import parseRetentionDef
 from carbon import log, state
 
 
@@ -64,7 +63,8 @@ class Archive:
     self.points = int(points)
 
   def __str__(self):
-    return "Archive = (Seconds per point: %d, Datapoints to save: %d)" % (self.secondsPerPoint, self.points)
+    return "Archive = (Seconds per point: %d, Datapoints to save: %d)" % (
+      self.secondsPerPoint, self.points)
 
   def getTuple(self):
     return (self.secondsPerPoint, self.points)
@@ -151,6 +151,7 @@ def loadAggregationSchemas():
   schemaList.append(defaultAggregation)
   return schemaList
 
-defaultArchive = Archive(60, 60 * 24 * 7)  # default retention for unclassified data (7 days of minutely data)
+# default retention for unclassified data (7 days of minutely data)
+defaultArchive = Archive(60, 60 * 24 * 7)
 defaultSchema = DefaultSchema('default', [defaultArchive])
 defaultAggregation = DefaultSchema('default', (None, None))

--- a/lib/carbon/tests/benchmark_aggregator.py
+++ b/lib/carbon/tests/benchmark_aggregator.py
@@ -1,7 +1,7 @@
 import timeit
 import time
 
-from carbon.aggregator.processor import AggregationProcessor, RuleManager, settings
+from carbon.aggregator.processor import AggregationProcessor, RuleManager
 from carbon.aggregator.buffers import BufferManager
 from carbon.tests.util import print_stats
 from carbon.conf import settings
@@ -42,7 +42,6 @@ def _bench_aggregator(name):
 
     buf = None
     for n in [1, 1000, 10000, 100000, 1000000, 10000000]:
-        count = 0
         processor = AggregationProcessor()
         processor.process(METRIC, (now, 1))
 
@@ -64,6 +63,7 @@ def _bench_aggregator(name):
 
 def main():
     settings.LOG_AGGREGATOR_MISSES = False
+
     class _Fake(object):
         def metricGenerated(self, metric, datapoint):
             pass

--- a/lib/carbon/tests/benchmark_cache.py
+++ b/lib/carbon/tests/benchmark_cache.py
@@ -14,20 +14,24 @@ strategies = {
     'timesorted': TimeSortedStrategy,
 }
 
+
 def command_store_foo():
     global count
     count = count + 1
     return metric_cache.store('foo', (count, 1.0))
+
 
 def command_store_foo_n():
     global count
     count = count + 1
     return metric_cache.store("foo.%d" % count, (count, 1.0))
 
+
 def command_drain():
     while metric_cache:
         metric_cache.drain_metric()
     return metric_cache.size
+
 
 def print_stats(n, t):
     usec = t * 1e6

--- a/lib/carbon/tests/benchmark_routers.py
+++ b/lib/carbon/tests/benchmark_routers.py
@@ -1,4 +1,3 @@
-import os
 import timeit
 
 from carbon.routers import DatapointRouter
@@ -30,7 +29,7 @@ def generateDestinations(n):
         host_id = i % 10
         instance_id = i
         port = 2000 + i
-        yield ('carbon%d' %  host_id, port, instance_id)
+        yield ('carbon%d' % host_id, port, instance_id)
 
 
 def benchmark(router_class):

--- a/lib/carbon/tests/test_aggregator_rules.py
+++ b/lib/carbon/tests/test_aggregator_rules.py
@@ -1,6 +1,6 @@
-import os
 import unittest
 from carbon.aggregator.rules import AggregationRule
+
 
 class AggregationRuleTest(unittest.TestCase):
 

--- a/lib/carbon/tests/test_cache.py
+++ b/lib/carbon/tests/test_cache.py
@@ -1,7 +1,10 @@
 import time
 from unittest import TestCase
 from mock import Mock, PropertyMock, patch
-from carbon.cache import MetricCache, _MetricCache, DrainStrategy, MaxStrategy, RandomStrategy, SortedStrategy, TimeSortedStrategy
+from carbon.cache import (
+  MetricCache, _MetricCache, DrainStrategy, MaxStrategy, RandomStrategy, SortedStrategy,
+  TimeSortedStrategy
+)
 
 
 class MetricCacheTest(TestCase):

--- a/lib/carbon/tests/test_client.py
+++ b/lib/carbon/tests/test_client.py
@@ -1,9 +1,12 @@
 import carbon.client as carbon_client
-from carbon.client import CarbonPickleClientFactory, CarbonPickleClientProtocol, CarbonLineClientProtocol, CarbonClientManager
+from carbon.client import (
+  CarbonPickleClientFactory, CarbonPickleClientProtocol, CarbonLineClientProtocol,
+  CarbonClientManager
+)
 from carbon.routers import DatapointRouter
 from carbon.tests.util import TestSettings
 from carbon import instrumentation
-import carbon.service
+import carbon.service  # NOQA
 
 from twisted.internet import reactor
 from twisted.internet.defer import Deferred
@@ -117,6 +120,7 @@ class CarbonClientFactoryTest(TestCase):
 @patch('carbon.state.instrumentation', Mock(spec=instrumentation))
 class CarbonClientManagerTest(TestCase):
   timeout = 1.0
+
   def setUp(self):
     self.router_mock = Mock(spec=DatapointRouter)
     self.factory_mock = Mock(spec=CarbonPickleClientFactory)

--- a/lib/carbon/tests/test_database.py
+++ b/lib/carbon/tests/test_database.py
@@ -24,7 +24,8 @@ class WhisperDatabaseTest(TestCase):
 
     def test_getTaggedFilesystemPath(self):
         result = self.database.getFilesystemPath('stats.example.counts;tag1=value1')
-        self.assertEquals(result, '/tmp/_tagged/872/252/stats-example-counts;tag1=value1.wsp')  # nosec
+        self.assertEquals(
+            result, '/tmp/_tagged/872/252/stats-example-counts;tag1=value1.wsp')  # nosec
 
 
 class CeresDatabaseTest(TestCase):

--- a/lib/carbon/tests/test_hashing.py
+++ b/lib/carbon/tests/test_hashing.py
@@ -1,6 +1,6 @@
-import os
 import unittest
 from carbon.hashing import ConsistentHashRing
+
 
 class HashIntegrityTest(unittest.TestCase):
 
@@ -8,79 +8,72 @@ class HashIntegrityTest(unittest.TestCase):
         """Make a cluster, verify we don't have positional collisions"""
         ring = ConsistentHashRing([])
         for n in range(2):
-            ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
+            ring.add_node(("192.168.10.%s" % str(10 + n), "%s" % str(10 + n)))
         self.assertEqual(
-                len([n[0] for n in ring.ring]),
+            len([n[0] for n in ring.ring]),
             len(set([n[0] for n in ring.ring])))
-
 
     def test_3_node_positional_itegrity(self):
         """Make a cluster, verify we don't have positional collisions"""
         ring = ConsistentHashRing([])
         for n in range(3):
-            ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
+            ring.add_node(("192.168.10.%s" % str(10 + n), "%s" % str(10 + n)))
         self.assertEqual(
-                len([n[0] for n in ring.ring]),
+            len([n[0] for n in ring.ring]),
             len(set([n[0] for n in ring.ring])))
-
 
     def test_4_node_positional_itegrity(self):
         """Make a cluster, verify we don't have positional collisions"""
         ring = ConsistentHashRing([])
         for n in range(4):
-            ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
+            ring.add_node(("192.168.10.%s" % str(10 + n), "%s" % str(10 + n)))
         self.assertEqual(
-                len([n[0] for n in ring.ring]),
+            len([n[0] for n in ring.ring]),
             len(set([n[0] for n in ring.ring])))
-
 
     def test_5_node_positional_itegrity(self):
         """Make a cluster, verify we don't have positional collisions"""
         ring = ConsistentHashRing([])
         for n in range(5):
-            ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
+            ring.add_node(("192.168.10.%s" % str(10 + n), "%s" % str(10 + n)))
         self.assertEqual(
-                len([n[0] for n in ring.ring]),
+            len([n[0] for n in ring.ring]),
             len(set([n[0] for n in ring.ring])))
-
 
     def test_6_node_positional_itegrity(self):
         """Make a cluster, verify we don't have positional collisions"""
         ring = ConsistentHashRing([])
         for n in range(6):
-            ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
+            ring.add_node(("192.168.10.%s" % str(10 + n), "%s" % str(10 + n)))
         self.assertEqual(
-                len([n[0] for n in ring.ring]),
+            len([n[0] for n in ring.ring]),
             len(set([n[0] for n in ring.ring])))
-
 
     def test_7_node_positional_itegrity(self):
         """Make a cluster, verify we don't have positional collisions"""
         ring = ConsistentHashRing([])
         for n in range(7):
-            ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
+            ring.add_node(("192.168.10.%s" % str(10 + n), "%s" % str(10 + n)))
         self.assertEqual(
-                len([n[0] for n in ring.ring]),
+            len([n[0] for n in ring.ring]),
             len(set([n[0] for n in ring.ring])))
-
 
     def test_8_node_positional_itegrity(self):
         """Make a cluster, verify we don't have positional collisions"""
         ring = ConsistentHashRing([])
         for n in range(8):
-            ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
+            ring.add_node(("192.168.10.%s" % str(10 + n), "%s" % str(10 + n)))
         self.assertEqual(
-                len([n[0] for n in ring.ring]),
+            len([n[0] for n in ring.ring]),
             len(set([n[0] for n in ring.ring])))
-
 
     def test_9_node_positional_itegrity(self):
         """Make a cluster, verify we don't have positional collisions"""
         ring = ConsistentHashRing([])
         for n in range(9):
-            ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
+            ring.add_node(("192.168.10.%s" % str(10 + n), "%s" % str(10 + n)))
         self.assertEqual(
-                len([n[0] for n in ring.ring]),
+            len([n[0] for n in ring.ring]),
             len(set([n[0] for n in ring.ring])))
 
 
@@ -90,79 +83,72 @@ class FNVHashIntegrityTest(unittest.TestCase):
         """Make a cluster, verify we don't have positional collisions"""
         ring = ConsistentHashRing([], hash_type='fnv1a_ch')
         for n in range(2):
-            ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
+            ring.add_node(("192.168.10.%s" % str(10 + n), "%s" % str(10 + n)))
         self.assertEqual(
-                len([n[0] for n in ring.ring]),
+            len([n[0] for n in ring.ring]),
             len(set([n[0] for n in ring.ring])))
-
 
     def test_3_node_positional_itegrity(self):
         """Make a cluster, verify we don't have positional collisions"""
         ring = ConsistentHashRing([], hash_type='fnv1a_ch')
         for n in range(3):
-            ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
+            ring.add_node(("192.168.10.%s" % str(10 + n), "%s" % str(10 + n)))
         self.assertEqual(
-                len([n[0] for n in ring.ring]),
+            len([n[0] for n in ring.ring]),
             len(set([n[0] for n in ring.ring])))
-
 
     def test_4_node_positional_itegrity(self):
         """Make a cluster, verify we don't have positional collisions"""
         ring = ConsistentHashRing([], hash_type='fnv1a_ch')
         for n in range(4):
-            ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
+            ring.add_node(("192.168.10.%s" % str(10 + n), "%s" % str(10 + n)))
         self.assertEqual(
-                len([n[0] for n in ring.ring]),
+            len([n[0] for n in ring.ring]),
             len(set([n[0] for n in ring.ring])))
-
 
     def test_5_node_positional_itegrity(self):
         """Make a cluster, verify we don't have positional collisions"""
         ring = ConsistentHashRing([], hash_type='fnv1a_ch')
         for n in range(5):
-            ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
+            ring.add_node(("192.168.10.%s" % str(10 + n), "%s" % str(10 + n)))
         self.assertEqual(
-                len([n[0] for n in ring.ring]),
+            len([n[0] for n in ring.ring]),
             len(set([n[0] for n in ring.ring])))
-
 
     def test_6_node_positional_itegrity(self):
         """Make a cluster, verify we don't have positional collisions"""
         ring = ConsistentHashRing([], hash_type='fnv1a_ch')
         for n in range(6):
-            ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
+            ring.add_node(("192.168.10.%s" % str(10 + n), "%s" % str(10 + n)))
         self.assertEqual(
-                len([n[0] for n in ring.ring]),
+            len([n[0] for n in ring.ring]),
             len(set([n[0] for n in ring.ring])))
-
 
     def test_7_node_positional_itegrity(self):
         """Make a cluster, verify we don't have positional collisions"""
         ring = ConsistentHashRing([], hash_type='fnv1a_ch')
         for n in range(7):
-            ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
+            ring.add_node(("192.168.10.%s" % str(10 + n), "%s" % str(10 + n)))
         self.assertEqual(
-                len([n[0] for n in ring.ring]),
+            len([n[0] for n in ring.ring]),
             len(set([n[0] for n in ring.ring])))
-
 
     def test_8_node_positional_itegrity(self):
         """Make a cluster, verify we don't have positional collisions"""
         ring = ConsistentHashRing([], hash_type='fnv1a_ch')
         for n in range(8):
-            ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
+            ring.add_node(("192.168.10.%s" % str(10 + n), "%s" % str(10 + n)))
         self.assertEqual(
-                len([n[0] for n in ring.ring]),
+            len([n[0] for n in ring.ring]),
             len(set([n[0] for n in ring.ring])))
-
 
     def test_9_node_positional_itegrity(self):
         """Make a cluster, verify we don't have positional collisions"""
         ring = ConsistentHashRing([], hash_type='fnv1a_ch')
         for n in range(9):
-            ring.add_node(("192.168.10.%s" % str(10+n),"%s" % str(10+n)))
+            ring.add_node(("192.168.10.%s" % str(10 + n), "%s" % str(10 + n)))
         self.assertEqual(
-                len([n[0] for n in ring.ring]),
+            len([n[0] for n in ring.ring]),
             len(set([n[0] for n in ring.ring])))
 
 
@@ -188,5 +174,5 @@ class ConsistentHashRingTestFNV1A(unittest.TestCase):
         self.assertEqual(hashring.get_node('hosts.worker2.cpu'),
                          ('127.0.0.3', '866a18b81f2dc4649517a1df13e26f28'))
         self.assertEqual(hashring.get_node(
-                        'stats.checkout.cluster.padamski-wro.api.v1.payment-initialize.count'),
-                        ('127.0.0.3', '866a18b81f2dc4649517a1df13e26f28'))
+                         'stats.checkout.cluster.padamski-wro.api.v1.payment-initialize.count'),
+                         ('127.0.0.3', '866a18b81f2dc4649517a1df13e26f28'))

--- a/lib/carbon/tests/test_protobuf.py
+++ b/lib/carbon/tests/test_protobuf.py
@@ -2,14 +2,14 @@ import carbon.client as carbon_client
 from carbon.routers import DatapointRouter
 from carbon.tests.util import TestSettings
 from carbon import instrumentation
-import carbon.service
+import carbon.service  # NOQA
 
 from carbon.carbon_pb2 import Payload
 from carbon.protobuf import CarbonProtobufClientFactory
 
 from twisted.internet import reactor
-from twisted.internet.defer import Deferred
-from twisted.internet.base import DelayedCall
+# from twisted.internet.defer import Deferred
+# from twisted.internet.base import DelayedCall
 from twisted.internet.task import deferLater
 from twisted.trial.unittest import TestCase
 from twisted.test.proto_helpers import StringTransport

--- a/lib/carbon/tests/test_protocols.py
+++ b/lib/carbon/tests/test_protocols.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from sys import version_info
 from carbon.protocols import MetricReceiver, MetricLineReceiver, \
     MetricDatagramReceiver, MetricPickleReceiver
 from carbon import events
@@ -15,11 +14,14 @@ import time
 
 class TestMetricReceiversHandler(TestCase):
   def test_build(self):
+    expected_plugins = sorted(['line', 'udp', 'pickle', 'protobuf'])
+
     # amqp not supported with py3
-    if version_info >= (3, 0):
-      expected_plugins = sorted(['line', 'udp', 'pickle', 'protobuf'])
-    else:
-      expected_plugins = sorted(['line', 'udp', 'pickle', 'amqp', 'protobuf'])
+    try:
+      import carbon.amqp_listener
+      expected_plugins.append('amqp')
+    except ImportError:
+      pass
 
     # Can't always test manhole because 'cryptography' can
     # be a pain to install and we don't want to make the CI

--- a/lib/carbon/tests/test_protocols.py
+++ b/lib/carbon/tests/test_protocols.py
@@ -2,7 +2,6 @@
 from sys import version_info
 from carbon.protocols import MetricReceiver, MetricLineReceiver, \
     MetricDatagramReceiver, MetricPickleReceiver
-from carbon.regexlist import WhiteList, BlackList
 from carbon import events
 from unittest import TestCase
 from mock import Mock, patch, call
@@ -26,7 +25,7 @@ class TestMetricReceiversHandler(TestCase):
     # be a pain to install and we don't want to make the CI
     # flaky because of that.
     try:
-      import carbon.manhole
+      import carbon.manhole  # NOQA
       expected_plugins.append('manhole')
     except ImportError:
       pass

--- a/lib/carbon/tests/test_service.py
+++ b/lib/carbon/tests/test_service.py
@@ -54,7 +54,7 @@ class TestSetupPipeline(TestCase):
 
   @patch('carbon.service.setupRewriterProcessor', new=Mock())
   def test_parses_processor_args(self):
-    #XXX Patch doesnt work on this import directly
+    # XXX Patch doesnt work on this import directly
     rewrite_mock = Mock()
     Processor.plugins['rewrite'] = rewrite_mock
     setupPipeline(['rewrite:pre'], self.root_service_mock, self.settings)

--- a/tox.ini
+++ b/tox.ini
@@ -34,3 +34,11 @@ commands =
 [flake8]
 max-line-length=100
 ignore=E111,E114,E121
+
+[travis]
+python =
+  2.7: py27, lint
+  3.4: py34
+  3.5: py35
+  3.6: py36, lint
+  pypy: pypy


### PR DESCRIPTION
This PR cleans up all the current issues identified by `tox -e lint` and adds jobs to run lint under py27 and py36 in Travis.  It also tweaks the detection for whether `txamqp` is supported so that it no longer depends on a hardcoded version check.