### PR TITLE
Added `--logger` and `--logfile` option.

### DIFF
--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -504,7 +504,15 @@ def get_default_parser(usage="%prog [options] <start|stop|status>"):
         "--instance",
         default='a',
         help="Manage a specific carbon instance")
-
+    parser.add_option(
+        "--logfile",
+        default='None',
+        help="Log to a specified file, - for stdout")
+    parser.add_option(
+        "--logger",
+        default='None',
+        help="A fully-qualified name to a log observer factory to use for the initial log "
+             "observer. Takes precedence over --logfile and --syslog (when available).")
     return parser
 
 

--- a/lib/carbon/util.py
+++ b/lib/carbon/util.py
@@ -85,6 +85,10 @@ def run_twistd_plugin(filename):
         twistd_options.extend(["--pidfile", options.pidfile])
     if options.umask:
         twistd_options.extend(["--umask", options.umask])
+    if options.logger:
+        twistd_options.extend(["--logger", options.logger])
+    if options.logger:
+        twistd_options.extend(["--logfile", options.logfile])
     if options.syslog:
         twistd_options.append("--syslog")
 
@@ -96,7 +100,8 @@ def run_twistd_plugin(filename):
 
     for option_name, option_value in vars(options).items():
         if (option_value is not None and option_name not in (
-                "debug", "profile", "profiler", "pidfile", "umask", "nodaemon", "syslog")):
+                "debug", "profile", "profiler", "pidfile", "umask", "nodaemon", "syslog",
+                "logger", "logfile")):
             twistd_options.extend(["--%s" % option_name.replace("_", "-"), option_value])
 
     # Finally, append extra args so that twistd has a chance to process them.


### PR DESCRIPTION
Enable `--logger` and `--logfile` option offered by Twistd

```
  --logfile=LOGFILE     Log to a specified file, - for stdout
  --logger=LOGGER       A fully-qualified name to a log observer factory to
                        use for the initial log observer. Takes precedence
                        over --logfile and --syslog (when available).
```