### PR TITLE
report test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,11 @@ dist
 *.pyc
 .idea
 *.iml
+.venv
+.coverage
+coverage.xml
+.tox
+conf/*.conf
+storage
+_trial_temp
+htmlcov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,36 @@
 # http://travis-ci.org/#!/graphite-project/carbon
 language: python
-python:
-    - 2.7
-    - 3.4
-    - 3.5
-    - 3.6
-    - pypy
+python: 2.7
+sudo: false
+
+matrix:
+  include:
+    - python: pypy
+      env:
+        - TOXENV=pypy
+    - python: 3.4
+      env:
+        - TOXENV=py34
+    - python: 3.5
+      env:
+        - TOXENV=py35
+    - python: 3.6
+      env:
+        - TOXENV=py36
+    - python: 3.6
+      env:
+        - TOXENV=lint
+
+env:
+  - TOXENV=py27
+  - TOXENV=lint
 
 install:
-    - pip install tox-travis
+  - pip install tox
 
 script:
-    - tox
+  - tox -e $TOXENV
 
-sudo: false
+after_success:
+  - pip install codecov
+  - codecov

--- a/tests-requirements.txt
+++ b/tests-requirements.txt
@@ -1,3 +1,4 @@
+coverage
 mock
 mocker
 nose

--- a/tox.ini
+++ b/tox.ini
@@ -13,10 +13,12 @@ setenv =
   GRAPHITE_NO_PREFIX=true
   PYTHONPATH={toxinidir}/lib
 commands =
-  trial carbon
+  coverage run --branch --include=lib/*,bin/* --omit=lib/carbon/tests/* "{envbindir}/trial" carbon
+  coverage xml
+  coverage report
 deps =
-     -rrequirements.txt
-     -rtests-requirements.txt
+  -rrequirements.txt
+  -rtests-requirements.txt
 
 [testenv:lint]
 deps =
@@ -34,11 +36,3 @@ commands =
 [flake8]
 max-line-length=100
 ignore=E111,E114,E121
-
-[travis]
-python =
-  2.7: py27, lint
-  3.4: py34
-  3.5: py35
-  3.6: py36, lint
-  pypy: pypy


### PR DESCRIPTION
This PR restructures the tox and travis setup to more closely match graphite-web, and to upload test coverage reports to codecov.

It also adds a handful of files to .gitignore