### PR TITLE
Fix hash position computation of fnv1a_ch.

### DIFF
--- a/lib/carbon/hashing.py
+++ b/lib/carbon/hashing.py
@@ -38,13 +38,10 @@ class ConsistentHashRing:
   def compute_ring_position(self, key):
     if self.hash_type == 'fnv1a_ch':
       if sys.version_info >= (3, 0):
-        big_hash = '{:x}'.format(int(fnv32a(key)))
+        big_hash = int(fnv32a(key))
       else:
-        big_hash = '{:x}'.format(int(fnv32a(str(key))))
-      if len(big_hash) > 4:
-          small_hash = int(big_hash[:4], 16) ^ int(big_hash[4:], 16)
-      else:
-          small_hash = int(big_hash, 16)
+        big_hash = int(fnv32a(str(key)))
+      small_hash = (big_hash >> 16) ^ (big_hash & 0xffff)
     else:
       if sys.version_info >= (3, 0):
         big_hash = md5(key.encode('utf-8')).hexdigest()

--- a/lib/carbon/tests/test_hashing.py
+++ b/lib/carbon/tests/test_hashing.py
@@ -161,8 +161,16 @@ class ConsistentHashRingTestFNV1A(unittest.TestCase):
         hashring = ConsistentHashRing(hosts, hash_type='fnv1a_ch')
         self.assertEqual(hashring.compute_ring_position('hosts.worker1.cpu'),
                          59573)
+        self.assertEqual(hashring.compute_ring_position('hosts.worker1.load'),
+                         57163)
         self.assertEqual(hashring.compute_ring_position('hosts.worker2.cpu'),
                          35749)
+        self.assertEqual(hashring.compute_ring_position('hosts.worker2.network'),
+                         43584)
+        self.assertEqual(hashring.compute_ring_position('hosts.worker3.cpu'),
+                         12600)
+        self.assertEqual(hashring.compute_ring_position('hosts.worker3.irq'),
+                         10052)
 
     def test_chr_get_node_fnv1a(self):
         hosts = [("127.0.0.1", "ba603c36342304ed77953f84ac4d357b"),


### PR DESCRIPTION
If the fnv1a hash of a given key returns a value less than `0x10000000`, then the high and low parts of the hash would be split incorrectly, resulting in a wrongly computed hash position.

This removes the hex formatting and splitting of the fnv1a hash, and just calculates the position using bit manipulation.

Fixes #714.