### PR TITLE
Fix hash position computation of fnv1a_ch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,18 @@ matrix:
         - TOXENV=py36
     - python: 3.6
       env:
+        - TOXENV=py36-pyhash
+    - python: 3.6
+      env:
         - TOXENV=lint
 
 env:
   - TOXENV=py27
+  - TOXENV=py27-pyhash
   - TOXENV=lint
+
+before_install:
+  - bash -c "if [[ '$TOXENV' == *pyhash* ]]; then sudo apt-get -qq update; sudo apt-get install -y libboost-python-dev; fi"
 
 install:
   - pip install tox

--- a/lib/carbon/hashing.py
+++ b/lib/carbon/hashing.py
@@ -31,9 +31,7 @@ except ImportError:
 
 
 def compactHash(string):
-  hash = md5()
-  hash.update(string.encode('utf-8'))
-  return hash.hexdigest()
+  return md5(string.encode('utf-8')).hexdigest()
 
 
 class ConsistentHashRing:
@@ -52,7 +50,7 @@ class ConsistentHashRing:
       big_hash = int(fnv32a(key.encode('utf-8')))
       small_hash = (big_hash >> 16) ^ (big_hash & 0xffff)
     else:
-      big_hash = compactHash(str(key))
+      big_hash = compactHash(key)
       small_hash = int(big_hash[:4], 16)
     return small_hash
 

--- a/lib/carbon/hashing.py
+++ b/lib/carbon/hashing.py
@@ -1,7 +1,4 @@
-try:
-  from hashlib import md5
-except ImportError:
-  from md5 import md5
+from hashlib import md5
 import bisect
 import sys
 
@@ -9,10 +6,10 @@ try:
   import pyhash
   hasher = pyhash.fnv1a_32()
 
-  def fnv32a(string, seed=0x811c9dc5):
-    return hasher(string, seed=seed)
+  def fnv32a(data, seed=0x811c9dc5):
+    return hasher(data, seed=seed)
 except ImportError:
-  def fnv32a(string, seed=0x811c9dc5):
+  def fnv32a(data, seed=0x811c9dc5):
     """
     FNV-1a Hash (http://isthe.com/chongo/tech/comp/fnv/) in Python.
     Taken from https://gist.github.com/vaiorabbit/5670985
@@ -20,16 +17,31 @@ except ImportError:
     hval = seed
     fnv_32_prime = 0x01000193
     uint32_max = 2 ** 32
-    for s in string:
-      hval = hval ^ ord(s)
-      hval = (hval * fnv_32_prime) % uint32_max
+    if sys.version_info >= (3, 0):
+      # data is a bytes object, s is an integer
+      for s in data:
+        hval = hval ^ s
+        hval = (hval * fnv_32_prime) % uint32_max
+    else:
+      # data is an str object, s is a single character
+      for s in data:
+        hval = hval ^ ord(s)
+        hval = (hval * fnv_32_prime) % uint32_max
     return hval
+
+
+def compactHash(string):
+  hash = md5()
+  hash.update(string.encode('utf-8'))
+  return hash.hexdigest()
 
 
 class ConsistentHashRing:
   def __init__(self, nodes, replica_count=100, hash_type='carbon_ch'):
     self.ring = []
+    self.ring_len = len(self.ring)
     self.nodes = set()
+    self.nodes_len = len(self.nodes)
     self.replica_count = replica_count
     self.hash_type = hash_type
     for node in nodes:
@@ -37,62 +49,60 @@ class ConsistentHashRing:
 
   def compute_ring_position(self, key):
     if self.hash_type == 'fnv1a_ch':
-      if sys.version_info >= (3, 0):
-        big_hash = int(fnv32a(key))
-      else:
-        big_hash = int(fnv32a(str(key)))
+      big_hash = int(fnv32a(key.encode('utf-8')))
       small_hash = (big_hash >> 16) ^ (big_hash & 0xffff)
     else:
-      if sys.version_info >= (3, 0):
-        big_hash = md5(key.encode('utf-8')).hexdigest()
-      else:
-        big_hash = md5(key).hexdigest()
+      big_hash = compactHash(str(key))
       small_hash = int(big_hash[:4], 16)
     return small_hash
 
-  def add_node(self, node):
-    self.nodes.add(node)
+  def add_node(self, key):
+    self.nodes.add(key)
+    self.nodes_len = len(self.nodes)
     for i in range(self.replica_count):
       if self.hash_type == 'fnv1a_ch':
-        replica_key = "%d-%s" % (i, node[1])
+        replica_key = "%d-%s" % (i, key[1])
       else:
-        replica_key = "%s:%d" % (node, i)
+        replica_key = "%s:%d" % (key, i)
       position = self.compute_ring_position(replica_key)
       while position in [r[0] for r in self.ring]:
         position = position + 1
-      entry = (position, node)
+      entry = (position, key)
       bisect.insort(self.ring, entry)
+    self.ring_len = len(self.ring)
 
-  def remove_node(self, node):
-    self.nodes.discard(node)
-    self.ring = [entry for entry in self.ring if entry[1] != node]
+  def remove_node(self, key):
+    self.nodes.discard(key)
+    self.nodes_len = len(self.nodes)
+    self.ring = [entry for entry in self.ring if entry[1] != key]
+    self.ring_len = len(self.ring)
 
   def get_node(self, key):
     assert self.ring
-    node = None
-    node_iter = self.get_nodes(key)
-    node = next(node_iter)
-    node_iter.close()
-    return node
+    position = self.compute_ring_position(key)
+    search_entry = (position, None)
+    index = bisect.bisect_left(self.ring, search_entry) % self.ring_len
+    entry = self.ring[index]
+    return entry[1]
 
   def get_nodes(self, key):
+    nodes = []
     if not self.ring:
-      return
-    if len(self.nodes) == 1:
-      # short circuit in simple 1-node case
-      for node in self.nodes:
-        yield node
-        return
-    nodes = set()
+      return nodes
+    if self.nodes_len == 1:
+      return list(self.nodes)
     position = self.compute_ring_position(key)
-    search_entry = (position, ())
-    index = bisect.bisect_left(self.ring, search_entry) % len(self.ring)
-    last_index = (index - 1) % len(self.ring)
-    while len(nodes) < len(self.nodes) and index != last_index:
+    search_entry = (position, None)
+    index = bisect.bisect_left(self.ring, search_entry) % self.ring_len
+    last_index = (index - 1) % self.ring_len
+    nodes_len = len(nodes)
+    while nodes_len < self.nodes_len and index != last_index:
       next_entry = self.ring[index]
       (position, next_node) = next_entry
       if next_node not in nodes:
-        nodes.add(next_node)
-        yield next_node
+        nodes.append(next_node)
+        nodes_len += 1
 
-      index = (index + 1) % len(self.ring)
+      index = (index + 1) % self.ring_len
+
+    return nodes

--- a/lib/carbon/hashing.py
+++ b/lib/carbon/hashing.py
@@ -38,13 +38,10 @@ class ConsistentHashRing:
   def compute_ring_position(self, key):
     if self.hash_type == 'fnv1a_ch':
       if sys.version_info >= (3, 0):
-        big_hash = '{:x}'.format(int(fnv32a(key)))
+        big_hash = int(fnv32a(key))
       else:
-        big_hash = '{:x}'.format(int(fnv32a(str(key))))
-      if len(big_hash) > 4:
-          small_hash = int(big_hash[:4], 16) ^ int(big_hash[4:], 16)
-      else:
-          small_hash = int(big_hash, 16)
+        big_hash = int(fnv32a(str(key)))
+      small_hash = (big_hash >> 16) ^ (big_hash & 0xffff)
     else:
       if sys.version_info >= (3, 0):
         big_hash = md5(key.encode('utf-8')).hexdigest()

--- a/lib/carbon/tests/test_hashing.py
+++ b/lib/carbon/tests/test_hashing.py
@@ -161,8 +161,16 @@ class ConsistentHashRingTestFNV1A(unittest.TestCase):
         hashring = ConsistentHashRing(hosts, hash_type='fnv1a_ch')
         self.assertEqual(hashring.compute_ring_position('hosts.worker1.cpu'),
                          59573)
+        self.assertEqual(hashring.compute_ring_position('hosts.worker1.load'),
+                         57163)
         self.assertEqual(hashring.compute_ring_position('hosts.worker2.cpu'),
                          35749)
+        self.assertEqual(hashring.compute_ring_position('hosts.worker2.network'),
+                         43584)
+        self.assertEqual(hashring.compute_ring_position('hosts.worker3.cpu'),
+                         12600)
+        self.assertEqual(hashring.compute_ring_position('hosts.worker3.irq'),
+                         10052)
 
     def test_chr_get_node_fnv1a(self):
         hosts = [("127.0.0.1", "ba603c36342304ed77953f84ac4d357b"),

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,6 @@
 [tox]
 envlist =
-  py27,
-  py34,
-  py35,
-  py36,
-  pypy,
+  py{27,34,35,36,py}{,-pyhash},
   lint,
   benchmark
 
@@ -19,6 +15,7 @@ commands =
 deps =
   -rrequirements.txt
   -rtests-requirements.txt
+  pyhash: pyhash
 
 [testenv:lint]
 deps =


### PR DESCRIPTION
This PR is an attempt to future-proof the fnv1a_ch hash computation by properly handling multi-byte characters in addition to applying the fix described in #714 and graphite-project/graphite-web#2165 & graphite-project/graphite-web#2168.

The way we use the fnv32a hash function is now consistent with other hash functions where any string is encoded into utf-8 before being hashed. This produces consistent results across python 2.x and 3.x with or without the pyhash library, and should be consistent with any third-party implementations.

This PR also syncs hashing.py between carbon and graphite-web to ensure they produce consistent results.