### PR TITLE
client: make sure the line client doesn't loose precision

### DIFF
--- a/lib/carbon/client.py
+++ b/lib/carbon/client.py
@@ -413,7 +413,7 @@ class CarbonLineClientProtocol(CarbonClientProtocol, LineOnlyReceiver):
 
   def _sendDatapointsNow(self, datapoints):
     for metric, datapoint in datapoints:
-        self.sendLine("%s %s %d" % (metric, datapoint[1], datapoint[0]))
+        self.sendLine("%s %f %d" % (metric, datapoint[1], datapoint[0]))
 
 
 class CarbonLineClientFactory(CarbonClientFactory):

--- a/lib/carbon/tests/test_client.py
+++ b/lib/carbon/tests/test_client.py
@@ -72,7 +72,7 @@ class CarbonLineClientProtocolTest(TestCase):
 
   def test_send_datapoints_now(self):
     datapoint = ('foo.bar', (1000000000, 1.0))
-    expected_line_to_send = "foo.bar 1.0 1000000000"
+    expected_line_to_send = "foo.bar 1.000000 1000000000"
 
     self.protocol._sendDatapointsNow([datapoint])
     self.protocol.sendLine.assert_called_once_with(expected_line_to_send)


### PR DESCRIPTION
For example '1.498566361088E12' would be printed as '1.49856636109e+12'
with the old version.