### PR TITLE
hashing: fix performance regression

### DIFF
--- a/lib/carbon/hashing.py
+++ b/lib/carbon/hashing.py
@@ -84,7 +84,7 @@ class ConsistentHashRing:
     return entry[1]
 
   def get_nodes(self, key):
-    nodes = []
+    nodes = set()
     if not self.ring:
       return nodes
     if self.nodes_len == 1:
@@ -98,7 +98,7 @@ class ConsistentHashRing:
       next_entry = self.ring[index]
       (position, next_node) = next_entry
       if next_node not in nodes:
-        nodes.append(next_node)
+        nodes.add(next_node)
         nodes_len += 1
 
       index = (index + 1) % self.ring_len


### PR DESCRIPTION
benchmarks before:
```
 consistent-hashing  deplication_factor: 1 diverse_replicas: 1 n_destinations: 1     datapoints: 100000 msecs: 36
 consistent-hashing  deplication_factor: 1 diverse_replicas: 1 n_destinations: 16    datapoints: 100000 msecs: 735
 consistent-hashing  deplication_factor: 1 diverse_replicas: 1 n_destinations: 32    datapoints: 100000 secs: 2.18479
 consistent-hashing  deplication_factor: 1 diverse_replicas: 1 n_destinations: 48    datapoints: 100000 secs: 5.39408
```

benchmarks after:
```
 consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 1     datapoints: 100000 msecs: 44
 consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 16    datapoints: 100000 msecs: 483
 consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 32    datapoints: 100000 msecs: 871
 consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 48    datapoints: 100000 secs: 1.36102
  
```