### PR TITLE
carbon: use a generator in routers instead of returning the full set

### DIFF
--- a/lib/carbon/hashing.py
+++ b/lib/carbon/hashing.py
@@ -99,9 +99,10 @@ class ConsistentHashRing:
   def get_nodes(self, key):
     nodes = set()
     if not self.ring:
-      return nodes
+      raise StopIteration
     if self.nodes_len == 1:
-      return list(self.nodes)
+      for node in self.nodes:
+        yield node
     position = self.compute_ring_position(key)
     search_entry = (position, None)
     index = bisect.bisect_left(self.ring, search_entry) % self.ring_len
@@ -113,7 +114,6 @@ class ConsistentHashRing:
       if next_node not in nodes:
         nodes.add(next_node)
         nodes_len += 1
+        yield next_node
 
       index = (index + 1) % self.ring_len
-
-    return nodes


### PR DESCRIPTION
- This preserve the order
- This stops iterating as soon as we have enough nodes (accoring
  to replication factor).

This restore pre-1.1.0 performances (/10 CPU usage).

Benchmarks follow .. (we should really move to pytest to have better output).

Before:
```
 consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 1     hash_type: None datapoints: 100000 msecs: 36
 consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 16    hash_type: None datapoints: 100000 msecs: 456
 consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 32    hash_type: None datapoints: 100000 msecs: 761
 consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 48    hash_type: None datapoints: 100000 secs: 1.28447
 consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 1     hash_type: None datapoints: 100000 msecs: 35
 consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 16    hash_type: None datapoints: 100000 msecs: 540
 consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 32    hash_type: None datapoints: 100000 msecs: 884
 consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 48    hash_type: None datapoints: 100000 secs: 1.26407
 consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 1     hash_type: None datapoints: 100000 msecs: 33
 consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 16    hash_type: None datapoints: 100000 msecs: 544
 consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 32    hash_type: None datapoints: 100000 msecs: 871
 consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 48    hash_type: None datapoints: 100000 secs: 1.34426
 consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 1     hash_type: None datapoints: 100000 msecs: 31
 consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 16    hash_type: None datapoints: 100000 msecs: 489
 consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 32    hash_type: None datapoints: 100000 msecs: 836
 consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 48    hash_type: None datapoints: 100000 secs: 1.32029
 consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 1     hash_type: carbon_ch datapoints: 100000 msecs: 32
 consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 16    hash_type: carbon_ch datapoints: 100000 msecs: 541
 consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 32    hash_type: carbon_ch datapoints: 100000 msecs: 840
 consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 48    hash_type: carbon_ch datapoints: 100000 secs: 1.34689
 consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 1     hash_type: carbon_ch datapoints: 100000 msecs: 30
 consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 16    hash_type: carbon_ch datapoints: 100000 msecs: 452
 consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 32    hash_type: carbon_ch datapoints: 100000 msecs: 813
 consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 48    hash_type: carbon_ch datapoints: 100000 secs: 1.2657
 consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 1     hash_type: carbon_ch datapoints: 100000 msecs: 31
 consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 16    hash_type: carbon_ch datapoints: 100000 msecs: 543
 consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 32    hash_type: carbon_ch datapoints: 100000 msecs: 839
 consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 48    hash_type: carbon_ch datapoints: 100000 secs: 1.31652
 consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 1     hash_type: carbon_ch datapoints: 100000 msecs: 33
 consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 16    hash_type: carbon_ch datapoints: 100000 msecs: 504
 consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 32    hash_type: carbon_ch datapoints: 100000 msecs: 905
 consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 48    hash_type: carbon_ch datapoints: 100000 secs: 1.27626
 consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 1     hash_type: fnv1a_ch datapoints: 100000 msecs: 30
 consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 16    hash_type: fnv1a_ch datapoints: 100000 msecs: 340
 consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 32    hash_type: fnv1a_ch datapoints: 100000 msecs: 615
 consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 48    hash_type: fnv1a_ch datapoints: 100000 msecs: 958
 consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 1     hash_type: fnv1a_ch datapoints: 100000 msecs: 27
 consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 16    hash_type: fnv1a_ch datapoints: 100000 msecs: 309
 consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 32    hash_type: fnv1a_ch datapoints: 100000 msecs: 600
 consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 48    hash_type: fnv1a_ch datapoints: 100000 msecs: 937
 consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 1     hash_type: fnv1a_ch datapoints: 100000 msecs: 29
 consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 16    hash_type: fnv1a_ch datapoints: 100000 msecs: 343
 consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 32    hash_type: fnv1a_ch datapoints: 100000 msecs: 677
 consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 48    hash_type: fnv1a_ch datapoints: 100000 secs: 1.06069
 consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 1     hash_type: fnv1a_ch datapoints: 100000 msecs: 26
 consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 16    hash_type: fnv1a_ch datapoints: 100000 msecs: 340
 consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 32    hash_type: fnv1a_ch datapoints: 100000 msecs: 632
 consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 48    hash_type: fnv1a_ch datapoints: 100000 msecs: 967
 consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 1     hash_type: mmh3_ch datapoints: 100000 msecs: 29
 consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 16    hash_type: mmh3_ch datapoints: 100000 msecs: 550
 consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 32    hash_type: mmh3_ch datapoints: 100000 msecs: 902
 consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 48    hash_type: mmh3_ch datapoints: 100000 secs: 1.26543
 consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 1     hash_type: mmh3_ch datapoints: 100000 msecs: 25
 consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 16    hash_type: mmh3_ch datapoints: 100000 msecs: 543
 consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 32    hash_type: mmh3_ch datapoints: 100000 msecs: 914
 consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 48    hash_type: mmh3_ch datapoints: 100000 secs: 1.25108
 consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 1     hash_type: mmh3_ch datapoints: 100000 msecs: 29
 consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 16    hash_type: mmh3_ch datapoints: 100000 msecs: 587
 consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 32    hash_type: mmh3_ch datapoints: 100000 msecs: 955
 consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 48    hash_type: mmh3_ch datapoints: 100000 secs: 1.34788
 consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 1     hash_type: mmh3_ch datapoints: 100000 msecs: 25
 consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 16    hash_type: mmh3_ch datapoints: 100000 msecs: 565
 consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 32    hash_type: mmh3_ch datapoints: 100000 msecs: 939
 consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 48    hash_type: mmh3_ch datapoints: 100000 secs: 1.3025
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 1     hash_type: None datapoints: 100000 msecs: 84
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 16    hash_type: None datapoints: 100000 msecs: 467
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 32    hash_type: None datapoints: 100000 msecs: 804
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 48    hash_type: None datapoints: 100000 secs: 1.27919
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 1     hash_type: None datapoints: 100000 msecs: 54
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 16    hash_type: None datapoints: 100000 msecs: 499
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 32    hash_type: None datapoints: 100000 msecs: 798
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 48    hash_type: None datapoints: 100000 secs: 1.22153
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 1     hash_type: None datapoints: 100000 msecs: 55
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 16    hash_type: None datapoints: 100000 msecs: 632
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 32    hash_type: None datapoints: 100000 msecs: 927
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 48    hash_type: None datapoints: 100000 secs: 1.38
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 1     hash_type: None datapoints: 100000 msecs: 52
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 16    hash_type: None datapoints: 100000 msecs: 572
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 32    hash_type: None datapoints: 100000 msecs: 898
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 48    hash_type: None datapoints: 100000 secs: 1.34593
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 1     hash_type: carbon_ch datapoints: 100000 msecs: 58
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 16    hash_type: carbon_ch datapoints: 100000 msecs: 485
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 32    hash_type: carbon_ch datapoints: 100000 msecs: 815
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 48    hash_type: carbon_ch datapoints: 100000 secs: 1.28422
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 1     hash_type: carbon_ch datapoints: 100000 msecs: 51
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 16    hash_type: carbon_ch datapoints: 100000 msecs: 513
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 32    hash_type: carbon_ch datapoints: 100000 msecs: 839
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 48    hash_type: carbon_ch datapoints: 100000 secs: 1.27546
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 1     hash_type: carbon_ch datapoints: 100000 msecs: 59
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 16    hash_type: carbon_ch datapoints: 100000 msecs: 576
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 32    hash_type: carbon_ch datapoints: 100000 msecs: 895
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 48    hash_type: carbon_ch datapoints: 100000 secs: 1.35766
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 1     hash_type: carbon_ch datapoints: 100000 msecs: 49
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 16    hash_type: carbon_ch datapoints: 100000 msecs: 584
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 32    hash_type: carbon_ch datapoints: 100000 msecs: 910
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 48    hash_type: carbon_ch datapoints: 100000 secs: 1.36756
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 1     hash_type: fnv1a_ch datapoints: 100000 msecs: 56
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 16    hash_type: fnv1a_ch datapoints: 100000 msecs: 331
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 32    hash_type: fnv1a_ch datapoints: 100000 msecs: 633
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 48    hash_type: fnv1a_ch datapoints: 100000 msecs: 979
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 1     hash_type: fnv1a_ch datapoints: 100000 msecs: 48
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 16    hash_type: fnv1a_ch datapoints: 100000 msecs: 326
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 32    hash_type: fnv1a_ch datapoints: 100000 msecs: 623
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 48    hash_type: fnv1a_ch datapoints: 100000 secs: 1.00448
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 1     hash_type: fnv1a_ch datapoints: 100000 msecs: 63
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 16    hash_type: fnv1a_ch datapoints: 100000 msecs: 399
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 32    hash_type: fnv1a_ch datapoints: 100000 msecs: 713
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 48    hash_type: fnv1a_ch datapoints: 100000 secs: 1.07203
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 1     hash_type: fnv1a_ch datapoints: 100000 msecs: 47
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 16    hash_type: fnv1a_ch datapoints: 100000 msecs: 370
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 32    hash_type: fnv1a_ch datapoints: 100000 msecs: 718
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 48    hash_type: fnv1a_ch datapoints: 100000 secs: 1.04931
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 1     hash_type: mmh3_ch datapoints: 100000 msecs: 49
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 16    hash_type: mmh3_ch datapoints: 100000 msecs: 616
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 32    hash_type: mmh3_ch datapoints: 100000 msecs: 967
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 48    hash_type: mmh3_ch datapoints: 100000 secs: 1.30962
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 1     hash_type: mmh3_ch datapoints: 100000 msecs: 48
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 16    hash_type: mmh3_ch datapoints: 100000 msecs: 610
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 32    hash_type: mmh3_ch datapoints: 100000 msecs: 946
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 48    hash_type: mmh3_ch datapoints: 100000 secs: 1.3382
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 1     hash_type: mmh3_ch datapoints: 100000 msecs: 54
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 16    hash_type: mmh3_ch datapoints: 100000 msecs: 667
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 32    hash_type: mmh3_ch datapoints: 100000 secs: 1.03899
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 48    hash_type: mmh3_ch datapoints: 100000 secs: 1.43022
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 1     hash_type: mmh3_ch datapoints: 100000 msecs: 49
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 16    hash_type: mmh3_ch datapoints: 100000 msecs: 649
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 32    hash_type: mmh3_ch datapoints: 100000 secs: 1.06055
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 48    hash_type: mmh3_ch datapoints: 100000 secs: 1.39583
 fast-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 1     hash_type: None datapoints: 100000 msecs: 246
 fast-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 16    hash_type: None datapoints: 100000 msecs: 236
 fast-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 32    hash_type: None datapoints: 100000 msecs: 259
 fast-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 48    hash_type: None datapoints: 100000 msecs: 238
 fast-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 1     hash_type: None datapoints: 100000 msecs: 239
 fast-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 16    hash_type: None datapoints: 100000 msecs: 241
 fast-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 32    hash_type: None datapoints: 100000 msecs: 240
 fast-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 48    hash_type: None datapoints: 100000 msecs: 253
 fast-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 1     hash_type: None datapoints: 100000 msecs: 240
 fast-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 16    hash_type: None datapoints: 100000 msecs: 298
 fast-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 32    hash_type: None datapoints: 100000 msecs: 296
 fast-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 48    hash_type: None datapoints: 100000 msecs: 298
 fast-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 1     hash_type: None datapoints: 100000 msecs: 244
 fast-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 16    hash_type: None datapoints: 100000 msecs: 280
 fast-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 32    hash_type: None datapoints: 100000 msecs: 279
 fast-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 48    hash_type: None datapoints: 100000 msecs: 277
 fast-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 1     hash_type: carbon_ch datapoints: 100000 msecs: 151
 fast-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 16    hash_type: carbon_ch datapoints: 100000 msecs: 175
 fast-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 32    hash_type: carbon_ch datapoints: 100000 msecs: 158
 fast-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 48    hash_type: carbon_ch datapoints: 100000 msecs: 174
 fast-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 1     hash_type: carbon_ch datapoints: 100000 msecs: 176
 fast-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 16    hash_type: carbon_ch datapoints: 100000 msecs: 170
 fast-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 32    hash_type: carbon_ch datapoints: 100000 msecs: 196
 fast-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 48    hash_type: carbon_ch datapoints: 100000 msecs: 181
 fast-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 1     hash_type: carbon_ch datapoints: 100000 msecs: 188
 fast-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 16    hash_type: carbon_ch datapoints: 100000 msecs: 250
 fast-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 32    hash_type: carbon_ch datapoints: 100000 msecs: 244
 fast-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 48    hash_type: carbon_ch datapoints: 100000 msecs: 265
 fast-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 1     hash_type: carbon_ch datapoints: 100000 msecs: 185
 fast-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 16    hash_type: carbon_ch datapoints: 100000 msecs: 249
 fast-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 32    hash_type: carbon_ch datapoints: 100000 msecs: 249
 fast-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 48    hash_type: carbon_ch datapoints: 100000 msecs: 261
 fast-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 1     hash_type: fnv1a_ch datapoints: 100000 msecs: 80
 fast-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 16    hash_type: fnv1a_ch datapoints: 100000 msecs: 53
 fast-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 32    hash_type: fnv1a_ch datapoints: 100000 msecs: 52
 fast-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 48    hash_type: fnv1a_ch datapoints: 100000 msecs: 53
 fast-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 1     hash_type: fnv1a_ch datapoints: 100000 msecs: 55
 fast-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 16    hash_type: fnv1a_ch datapoints: 100000 msecs: 52
 fast-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 32    hash_type: fnv1a_ch datapoints: 100000 msecs: 52
 fast-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 48    hash_type: fnv1a_ch datapoints: 100000 msecs: 51
 fast-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 1     hash_type: fnv1a_ch datapoints: 100000 msecs: 52
 fast-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 16    hash_type: fnv1a_ch datapoints: 100000 msecs: 98
 fast-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 32    hash_type: fnv1a_ch datapoints: 100000 msecs: 103
 fast-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 48    hash_type: fnv1a_ch datapoints: 100000 msecs: 105
 fast-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 1     hash_type: fnv1a_ch datapoints: 100000 msecs: 49
 fast-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 16    hash_type: fnv1a_ch datapoints: 100000 msecs: 90
 fast-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 32    hash_type: fnv1a_ch datapoints: 100000 msecs: 90
 fast-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 48    hash_type: fnv1a_ch datapoints: 100000 msecs: 89
 fast-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 1     hash_type: mmh3_ch datapoints: 100000 msecs: 253
 fast-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 16    hash_type: mmh3_ch datapoints: 100000 msecs: 250
 fast-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 32    hash_type: mmh3_ch datapoints: 100000 msecs: 254
 fast-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 48    hash_type: mmh3_ch datapoints: 100000 msecs: 247
 fast-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 1     hash_type: mmh3_ch datapoints: 100000 msecs: 231
 fast-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 16    hash_type: mmh3_ch datapoints: 100000 msecs: 240
 fast-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 32    hash_type: mmh3_ch datapoints: 100000 msecs: 238
 fast-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 48    hash_type: mmh3_ch datapoints: 100000 msecs: 253
 fast-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 1     hash_type: mmh3_ch datapoints: 100000 msecs: 238
 fast-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 16    hash_type: mmh3_ch datapoints: 100000 msecs: 297
 fast-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 32    hash_type: mmh3_ch datapoints: 100000 msecs: 296
 fast-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 48    hash_type: mmh3_ch datapoints: 100000 msecs: 296
 fast-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 1     hash_type: mmh3_ch datapoints: 100000 msecs: 249
 fast-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 16    hash_type: mmh3_ch datapoints: 100000 msecs: 285
 fast-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 32    hash_type: mmh3_ch datapoints: 100000 msecs: 281
 fast-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 48    hash_type: mmh3_ch datapoints: 100000 msecs: 279
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 1     hash_type: None datapoints: 100000 msecs: 311
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 16    hash_type: None datapoints: 100000 msecs: 275
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 32    hash_type: None datapoints: 100000 msecs: 273
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 48    hash_type: None datapoints: 100000 msecs: 269
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 1     hash_type: None datapoints: 100000 msecs: 301
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 16    hash_type: None datapoints: 100000 msecs: 283
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 32    hash_type: None datapoints: 100000 msecs: 285
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 48    hash_type: None datapoints: 100000 msecs: 307
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 1     hash_type: None datapoints: 100000 msecs: 269
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 16    hash_type: None datapoints: 100000 msecs: 382
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 32    hash_type: None datapoints: 100000 msecs: 387
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 48    hash_type: None datapoints: 100000 msecs: 385
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 1     hash_type: None datapoints: 100000 msecs: 270
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 16    hash_type: None datapoints: 100000 msecs: 376
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 32    hash_type: None datapoints: 100000 msecs: 389
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 48    hash_type: None datapoints: 100000 msecs: 365
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 1     hash_type: carbon_ch datapoints: 100000 msecs: 204
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 16    hash_type: carbon_ch datapoints: 100000 msecs: 190
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 32    hash_type: carbon_ch datapoints: 100000 msecs: 211
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 48    hash_type: carbon_ch datapoints: 100000 msecs: 220
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 1     hash_type: carbon_ch datapoints: 100000 msecs: 210
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 16    hash_type: carbon_ch datapoints: 100000 msecs: 229
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 32    hash_type: carbon_ch datapoints: 100000 msecs: 237
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 48    hash_type: carbon_ch datapoints: 100000 msecs: 226
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 1     hash_type: carbon_ch datapoints: 100000 msecs: 216
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 16    hash_type: carbon_ch datapoints: 100000 msecs: 317
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 32    hash_type: carbon_ch datapoints: 100000 msecs: 320
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 48    hash_type: carbon_ch datapoints: 100000 msecs: 320
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 1     hash_type: carbon_ch datapoints: 100000 msecs: 221
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 16    hash_type: carbon_ch datapoints: 100000 msecs: 324
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 32    hash_type: carbon_ch datapoints: 100000 msecs: 347
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 48    hash_type: carbon_ch datapoints: 100000 msecs: 322
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 1     hash_type: fnv1a_ch datapoints: 100000 msecs: 88
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 16    hash_type: fnv1a_ch datapoints: 100000 msecs: 78
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 32    hash_type: fnv1a_ch datapoints: 100000 msecs: 79
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 48    hash_type: fnv1a_ch datapoints: 100000 msecs: 80
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 1     hash_type: fnv1a_ch datapoints: 100000 msecs: 83
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 16    hash_type: fnv1a_ch datapoints: 100000 msecs: 87
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 32    hash_type: fnv1a_ch datapoints: 100000 msecs: 82
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 48    hash_type: fnv1a_ch datapoints: 100000 msecs: 80
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 1     hash_type: fnv1a_ch datapoints: 100000 msecs: 79
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 16    hash_type: fnv1a_ch datapoints: 100000 msecs: 152
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 32    hash_type: fnv1a_ch datapoints: 100000 msecs: 158
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 48    hash_type: fnv1a_ch datapoints: 100000 msecs: 160
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 1     hash_type: fnv1a_ch datapoints: 100000 msecs: 75
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 16    hash_type: fnv1a_ch datapoints: 100000 msecs: 146
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 32    hash_type: fnv1a_ch datapoints: 100000 msecs: 148
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 48    hash_type: fnv1a_ch datapoints: 100000 msecs: 150
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 1     hash_type: mmh3_ch datapoints: 100000 msecs: 286
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 16    hash_type: mmh3_ch datapoints: 100000 msecs: 303
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 32    hash_type: mmh3_ch datapoints: 100000 msecs: 276
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 48    hash_type: mmh3_ch datapoints: 100000 msecs: 280
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 1     hash_type: mmh3_ch datapoints: 100000 msecs: 291
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 16    hash_type: mmh3_ch datapoints: 100000 msecs: 281
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 32    hash_type: mmh3_ch datapoints: 100000 msecs: 283
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 48    hash_type: mmh3_ch datapoints: 100000 msecs: 301
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 1     hash_type: mmh3_ch datapoints: 100000 msecs: 273
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 16    hash_type: mmh3_ch datapoints: 100000 msecs: 366
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 32    hash_type: mmh3_ch datapoints: 100000 msecs: 373
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 48    hash_type: mmh3_ch datapoints: 100000 msecs: 380
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 1     hash_type: mmh3_ch datapoints: 100000 msecs: 266
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 16    hash_type: mmh3_ch datapoints: 100000 msecs: 372
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 32    hash_type: mmh3_ch datapoints: 100000 msecs: 389
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 48    hash_type: mmh3_ch datapoints: 100000 msecs: 363
```

After
```
 consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 1     hash_type: None datapoints: 100000 msecs: 40
 consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 16    hash_type: None datapoints: 100000 msecs: 195
 consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 32    hash_type: None datapoints: 100000 msecs: 201
 consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 48    hash_type: None datapoints: 100000 msecs: 210
 consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 1     hash_type: None datapoints: 100000 msecs: 222
 consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 16    hash_type: None datapoints: 100000 msecs: 221
 consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 32    hash_type: None datapoints: 100000 msecs: 236
 consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 48    hash_type: None datapoints: 100000 msecs: 229
 consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 1     hash_type: None datapoints: 100000 msecs: 229
 consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 16    hash_type: None datapoints: 100000 msecs: 351
 consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 32    hash_type: None datapoints: 100000 msecs: 326
 consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 48    hash_type: None datapoints: 100000 msecs: 320
 consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 1     hash_type: None datapoints: 100000 msecs: 227
 consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 16    hash_type: None datapoints: 100000 msecs: 316
 consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 32    hash_type: None datapoints: 100000 msecs: 317
 consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 48    hash_type: None datapoints: 100000 msecs: 307
 consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 1     hash_type: carbon_ch datapoints: 100000 msecs: 32
 consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 16    hash_type: carbon_ch datapoints: 100000 msecs: 220
 consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 32    hash_type: carbon_ch datapoints: 100000 msecs: 220
 consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 48    hash_type: carbon_ch datapoints: 100000 msecs: 225
 consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 1     hash_type: carbon_ch datapoints: 100000 msecs: 231
 consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 16    hash_type: carbon_ch datapoints: 100000 msecs: 231
 consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 32    hash_type: carbon_ch datapoints: 100000 msecs: 255
 consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 48    hash_type: carbon_ch datapoints: 100000 msecs: 234
 consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 1     hash_type: carbon_ch datapoints: 100000 msecs: 228
 consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 16    hash_type: carbon_ch datapoints: 100000 msecs: 334
 consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 32    hash_type: carbon_ch datapoints: 100000 msecs: 328
 consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 48    hash_type: carbon_ch datapoints: 100000 msecs: 319
 consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 1     hash_type: carbon_ch datapoints: 100000 msecs: 229
 consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 16    hash_type: carbon_ch datapoints: 100000 msecs: 322
 consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 32    hash_type: carbon_ch datapoints: 100000 msecs: 315
 consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 48    hash_type: carbon_ch datapoints: 100000 msecs: 310
 consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 1     hash_type: fnv1a_ch datapoints: 100000 msecs: 31
 consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 16    hash_type: fnv1a_ch datapoints: 100000 msecs: 90
 consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 32    hash_type: fnv1a_ch datapoints: 100000 msecs: 87
 consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 48    hash_type: fnv1a_ch datapoints: 100000 msecs: 89
 consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 1     hash_type: fnv1a_ch datapoints: 100000 msecs: 79
 consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 16    hash_type: fnv1a_ch datapoints: 100000 msecs: 93
 consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 32    hash_type: fnv1a_ch datapoints: 100000 msecs: 98
 consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 48    hash_type: fnv1a_ch datapoints: 100000 msecs: 102
 consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 1     hash_type: fnv1a_ch datapoints: 100000 msecs: 88
 consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 16    hash_type: fnv1a_ch datapoints: 100000 msecs: 191
 consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 32    hash_type: fnv1a_ch datapoints: 100000 msecs: 189
 consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 48    hash_type: fnv1a_ch datapoints: 100000 msecs: 180
 consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 1     hash_type: fnv1a_ch datapoints: 100000 msecs: 89
 consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 16    hash_type: fnv1a_ch datapoints: 100000 msecs: 166
 consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 32    hash_type: fnv1a_ch datapoints: 100000 msecs: 171
 consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 48    hash_type: fnv1a_ch datapoints: 100000 msecs: 173
 consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 1     hash_type: mmh3_ch datapoints: 100000 msecs: 28
 consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 16    hash_type: mmh3_ch datapoints: 100000 msecs: 293
 consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 32    hash_type: mmh3_ch datapoints: 100000 msecs: 290
 consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 48    hash_type: mmh3_ch datapoints: 100000 msecs: 310
 consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 1     hash_type: mmh3_ch datapoints: 100000 msecs: 246
 consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 16    hash_type: mmh3_ch datapoints: 100000 msecs: 285
 consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 32    hash_type: mmh3_ch datapoints: 100000 msecs: 295
 consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 48    hash_type: mmh3_ch datapoints: 100000 msecs: 306
 consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 1     hash_type: mmh3_ch datapoints: 100000 msecs: 278
 consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 16    hash_type: mmh3_ch datapoints: 100000 msecs: 400
 consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 32    hash_type: mmh3_ch datapoints: 100000 msecs: 419
 consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 48    hash_type: mmh3_ch datapoints: 100000 msecs: 428
 consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 1     hash_type: mmh3_ch datapoints: 100000 msecs: 254
 consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 16    hash_type: mmh3_ch datapoints: 100000 msecs: 385
 consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 32    hash_type: mmh3_ch datapoints: 100000 msecs: 380
 consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 48    hash_type: mmh3_ch datapoints: 100000 msecs: 378
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 1     hash_type: None datapoints: 100000 msecs: 65
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 16    hash_type: None datapoints: 100000 msecs: 242
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 32    hash_type: None datapoints: 100000 msecs: 233
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 48    hash_type: None datapoints: 100000 msecs: 241
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 1     hash_type: None datapoints: 100000 msecs: 248
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 16    hash_type: None datapoints: 100000 msecs: 276
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 32    hash_type: None datapoints: 100000 msecs: 260
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 48    hash_type: None datapoints: 100000 msecs: 275
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 1     hash_type: None datapoints: 100000 msecs: 278
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 16    hash_type: None datapoints: 100000 msecs: 414
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 32    hash_type: None datapoints: 100000 msecs: 386
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 48    hash_type: None datapoints: 100000 msecs: 394
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 1     hash_type: None datapoints: 100000 msecs: 293
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 16    hash_type: None datapoints: 100000 msecs: 401
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 32    hash_type: None datapoints: 100000 msecs: 404
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 48    hash_type: None datapoints: 100000 msecs: 400
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 1     hash_type: carbon_ch datapoints: 100000 msecs: 60
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 16    hash_type: carbon_ch datapoints: 100000 msecs: 251
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 32    hash_type: carbon_ch datapoints: 100000 msecs: 285
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 48    hash_type: carbon_ch datapoints: 100000 msecs: 292
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 1     hash_type: carbon_ch datapoints: 100000 msecs: 237
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 16    hash_type: carbon_ch datapoints: 100000 msecs: 288
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 32    hash_type: carbon_ch datapoints: 100000 msecs: 297
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 48    hash_type: carbon_ch datapoints: 100000 msecs: 299
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 1     hash_type: carbon_ch datapoints: 100000 msecs: 257
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 16    hash_type: carbon_ch datapoints: 100000 msecs: 404
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 32    hash_type: carbon_ch datapoints: 100000 msecs: 415
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 48    hash_type: carbon_ch datapoints: 100000 msecs: 422
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 1     hash_type: carbon_ch datapoints: 100000 msecs: 266
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 16    hash_type: carbon_ch datapoints: 100000 msecs: 394
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 32    hash_type: carbon_ch datapoints: 100000 msecs: 406
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 48    hash_type: carbon_ch datapoints: 100000 msecs: 407
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 1     hash_type: fnv1a_ch datapoints: 100000 msecs: 57
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 16    hash_type: fnv1a_ch datapoints: 100000 msecs: 113
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 32    hash_type: fnv1a_ch datapoints: 100000 msecs: 118
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 48    hash_type: fnv1a_ch datapoints: 100000 msecs: 120
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 1     hash_type: fnv1a_ch datapoints: 100000 msecs: 100
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 16    hash_type: fnv1a_ch datapoints: 100000 msecs: 121
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 32    hash_type: fnv1a_ch datapoints: 100000 msecs: 127
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 48    hash_type: fnv1a_ch datapoints: 100000 msecs: 132
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 1     hash_type: fnv1a_ch datapoints: 100000 msecs: 116
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 16    hash_type: fnv1a_ch datapoints: 100000 msecs: 228
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 32    hash_type: fnv1a_ch datapoints: 100000 msecs: 273
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 48    hash_type: fnv1a_ch datapoints: 100000 msecs: 244
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 1     hash_type: fnv1a_ch datapoints: 100000 msecs: 127
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 16    hash_type: fnv1a_ch datapoints: 100000 msecs: 220
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 32    hash_type: fnv1a_ch datapoints: 100000 msecs: 226
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 48    hash_type: fnv1a_ch datapoints: 100000 msecs: 230
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 1     hash_type: mmh3_ch datapoints: 100000 msecs: 51
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 16    hash_type: mmh3_ch datapoints: 100000 msecs: 331
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 32    hash_type: mmh3_ch datapoints: 100000 msecs: 358
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 48    hash_type: mmh3_ch datapoints: 100000 msecs: 352
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 1     hash_type: mmh3_ch datapoints: 100000 msecs: 291
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 16    hash_type: mmh3_ch datapoints: 100000 msecs: 333
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 32    hash_type: mmh3_ch datapoints: 100000 msecs: 347
 aggregated-consistent-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 48    hash_type: mmh3_ch datapoints: 100000 msecs: 351
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 1     hash_type: mmh3_ch datapoints: 100000 msecs: 311
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 16    hash_type: mmh3_ch datapoints: 100000 msecs: 477
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 32    hash_type: mmh3_ch datapoints: 100000 msecs: 478
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 48    hash_type: mmh3_ch datapoints: 100000 msecs: 507
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 1     hash_type: mmh3_ch datapoints: 100000 msecs: 334
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 16    hash_type: mmh3_ch datapoints: 100000 msecs: 454
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 32    hash_type: mmh3_ch datapoints: 100000 msecs: 463
 aggregated-consistent-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 48    hash_type: mmh3_ch datapoints: 100000 msecs: 516
 fast-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 1     hash_type: None datapoints: 100000 msecs: 215
 fast-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 16    hash_type: None datapoints: 100000 msecs: 211
 fast-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 32    hash_type: None datapoints: 100000 msecs: 208
 fast-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 48    hash_type: None datapoints: 100000 msecs: 225
 fast-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 1     hash_type: None datapoints: 100000 msecs: 216
 fast-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 16    hash_type: None datapoints: 100000 msecs: 217
 fast-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 32    hash_type: None datapoints: 100000 msecs: 214
 fast-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 48    hash_type: None datapoints: 100000 msecs: 214
 fast-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 1     hash_type: None datapoints: 100000 msecs: 204
 fast-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 16    hash_type: None datapoints: 100000 msecs: 295
 fast-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 32    hash_type: None datapoints: 100000 msecs: 268
 fast-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 48    hash_type: None datapoints: 100000 msecs: 263
 fast-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 1     hash_type: None datapoints: 100000 msecs: 199
 fast-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 16    hash_type: None datapoints: 100000 msecs: 252
 fast-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 32    hash_type: None datapoints: 100000 msecs: 260
 fast-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 48    hash_type: None datapoints: 100000 msecs: 251
 fast-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 1     hash_type: carbon_ch datapoints: 100000 msecs: 151
 fast-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 16    hash_type: carbon_ch datapoints: 100000 msecs: 157
 fast-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 32    hash_type: carbon_ch datapoints: 100000 msecs: 176
 fast-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 48    hash_type: carbon_ch datapoints: 100000 msecs: 169
 fast-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 1     hash_type: carbon_ch datapoints: 100000 msecs: 169
 fast-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 16    hash_type: carbon_ch datapoints: 100000 msecs: 183
 fast-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 32    hash_type: carbon_ch datapoints: 100000 msecs: 176
 fast-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 48    hash_type: carbon_ch datapoints: 100000 msecs: 170
 fast-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 1     hash_type: carbon_ch datapoints: 100000 msecs: 193
 fast-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 16    hash_type: carbon_ch datapoints: 100000 msecs: 228
 fast-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 32    hash_type: carbon_ch datapoints: 100000 msecs: 229
 fast-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 48    hash_type: carbon_ch datapoints: 100000 msecs: 252
 fast-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 1     hash_type: carbon_ch datapoints: 100000 msecs: 175
 fast-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 16    hash_type: carbon_ch datapoints: 100000 msecs: 236
 fast-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 32    hash_type: carbon_ch datapoints: 100000 msecs: 228
 fast-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 48    hash_type: carbon_ch datapoints: 100000 msecs: 222
 fast-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 1     hash_type: fnv1a_ch datapoints: 100000 msecs: 60
 fast-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 16    hash_type: fnv1a_ch datapoints: 100000 msecs: 52
 fast-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 32    hash_type: fnv1a_ch datapoints: 100000 msecs: 80
 fast-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 48    hash_type: fnv1a_ch datapoints: 100000 msecs: 53
 fast-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 1     hash_type: fnv1a_ch datapoints: 100000 msecs: 55
 fast-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 16    hash_type: fnv1a_ch datapoints: 100000 msecs: 51
 fast-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 32    hash_type: fnv1a_ch datapoints: 100000 msecs: 64
 fast-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 48    hash_type: fnv1a_ch datapoints: 100000 msecs: 58
 fast-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 1     hash_type: fnv1a_ch datapoints: 100000 msecs: 53
 fast-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 16    hash_type: fnv1a_ch datapoints: 100000 msecs: 96
 fast-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 32    hash_type: fnv1a_ch datapoints: 100000 msecs: 103
 fast-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 48    hash_type: fnv1a_ch datapoints: 100000 msecs: 105
 fast-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 1     hash_type: fnv1a_ch datapoints: 100000 msecs: 48
 fast-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 16    hash_type: fnv1a_ch datapoints: 100000 msecs: 88
 fast-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 32    hash_type: fnv1a_ch datapoints: 100000 msecs: 90
 fast-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 48    hash_type: fnv1a_ch datapoints: 100000 msecs: 87
 fast-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 1     hash_type: mmh3_ch datapoints: 100000 msecs: 222
 fast-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 16    hash_type: mmh3_ch datapoints: 100000 msecs: 216
 fast-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 32    hash_type: mmh3_ch datapoints: 100000 msecs: 215
 fast-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 48    hash_type: mmh3_ch datapoints: 100000 msecs: 230
 fast-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 1     hash_type: mmh3_ch datapoints: 100000 msecs: 208
 fast-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 16    hash_type: mmh3_ch datapoints: 100000 msecs: 214
 fast-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 32    hash_type: mmh3_ch datapoints: 100000 msecs: 214
 fast-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 48    hash_type: mmh3_ch datapoints: 100000 msecs: 214
 fast-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 1     hash_type: mmh3_ch datapoints: 100000 msecs: 204
 fast-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 16    hash_type: mmh3_ch datapoints: 100000 msecs: 282
 fast-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 32    hash_type: mmh3_ch datapoints: 100000 msecs: 263
 fast-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 48    hash_type: mmh3_ch datapoints: 100000 msecs: 261
 fast-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 1     hash_type: mmh3_ch datapoints: 100000 msecs: 205
 fast-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 16    hash_type: mmh3_ch datapoints: 100000 msecs: 261
 fast-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 32    hash_type: mmh3_ch datapoints: 100000 msecs: 279
 fast-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 48    hash_type: mmh3_ch datapoints: 100000 msecs: 252
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 1     hash_type: None datapoints: 100000 msecs: 251
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 16    hash_type: None datapoints: 100000 msecs: 250
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 32    hash_type: None datapoints: 100000 msecs: 267
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 48    hash_type: None datapoints: 100000 msecs: 241
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 1     hash_type: None datapoints: 100000 msecs: 240
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 16    hash_type: None datapoints: 100000 msecs: 248
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 32    hash_type: None datapoints: 100000 msecs: 267
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 48    hash_type: None datapoints: 100000 msecs: 240
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 1     hash_type: None datapoints: 100000 msecs: 235
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 16    hash_type: None datapoints: 100000 msecs: 349
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 32    hash_type: None datapoints: 100000 msecs: 371
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 48    hash_type: None datapoints: 100000 msecs: 333
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 1     hash_type: None datapoints: 100000 msecs: 231
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 16    hash_type: None datapoints: 100000 msecs: 322
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 32    hash_type: None datapoints: 100000 msecs: 342
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 48    hash_type: None datapoints: 100000 msecs: 325
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 1     hash_type: carbon_ch datapoints: 100000 msecs: 193
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 16    hash_type: carbon_ch datapoints: 100000 msecs: 182
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 32    hash_type: carbon_ch datapoints: 100000 msecs: 207
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 48    hash_type: carbon_ch datapoints: 100000 msecs: 194
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 1     hash_type: carbon_ch datapoints: 100000 msecs: 216
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 16    hash_type: carbon_ch datapoints: 100000 msecs: 219
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 32    hash_type: carbon_ch datapoints: 100000 msecs: 205
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 48    hash_type: carbon_ch datapoints: 100000 msecs: 227
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 1     hash_type: carbon_ch datapoints: 100000 msecs: 229
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 16    hash_type: carbon_ch datapoints: 100000 msecs: 293
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 32    hash_type: carbon_ch datapoints: 100000 msecs: 315
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 48    hash_type: carbon_ch datapoints: 100000 msecs: 318
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 1     hash_type: carbon_ch datapoints: 100000 msecs: 212
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 16    hash_type: carbon_ch datapoints: 100000 msecs: 303
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 32    hash_type: carbon_ch datapoints: 100000 msecs: 311
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 48    hash_type: carbon_ch datapoints: 100000 msecs: 317
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 1     hash_type: fnv1a_ch datapoints: 100000 msecs: 91
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 16    hash_type: fnv1a_ch datapoints: 100000 msecs: 79
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 32    hash_type: fnv1a_ch datapoints: 100000 msecs: 82
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 48    hash_type: fnv1a_ch datapoints: 100000 msecs: 80
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 1     hash_type: fnv1a_ch datapoints: 100000 msecs: 78
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 16    hash_type: fnv1a_ch datapoints: 100000 msecs: 76
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 32    hash_type: fnv1a_ch datapoints: 100000 msecs: 77
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 48    hash_type: fnv1a_ch datapoints: 100000 msecs: 76
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 1     hash_type: fnv1a_ch datapoints: 100000 msecs: 78
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 16    hash_type: fnv1a_ch datapoints: 100000 msecs: 153
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 32    hash_type: fnv1a_ch datapoints: 100000 msecs: 163
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 48    hash_type: fnv1a_ch datapoints: 100000 msecs: 164
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 1     hash_type: fnv1a_ch datapoints: 100000 msecs: 73
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 16    hash_type: fnv1a_ch datapoints: 100000 msecs: 144
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 32    hash_type: fnv1a_ch datapoints: 100000 msecs: 148
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 48    hash_type: fnv1a_ch datapoints: 100000 msecs: 146
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 1     hash_type: mmh3_ch datapoints: 100000 msecs: 263
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 16    hash_type: mmh3_ch datapoints: 100000 msecs: 272
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 32    hash_type: mmh3_ch datapoints: 100000 msecs: 247
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 1 n_destinations: 48    hash_type: mmh3_ch datapoints: 100000 msecs: 245
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 1     hash_type: mmh3_ch datapoints: 100000 msecs: 234
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 16    hash_type: mmh3_ch datapoints: 100000 msecs: 263
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 32    hash_type: mmh3_ch datapoints: 100000 msecs: 247
 fast-aggregated-hashing  replication_factor: 1 diverse_replicas: 0 n_destinations: 48    hash_type: mmh3_ch datapoints: 100000 msecs: 246
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 1     hash_type: mmh3_ch datapoints: 100000 msecs: 243
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 16    hash_type: mmh3_ch datapoints: 100000 msecs: 354
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 32    hash_type: mmh3_ch datapoints: 100000 msecs: 339
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 1 n_destinations: 48    hash_type: mmh3_ch datapoints: 100000 msecs: 335
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 1     hash_type: mmh3_ch datapoints: 100000 msecs: 249
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 16    hash_type: mmh3_ch datapoints: 100000 msecs: 322
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 32    hash_type: mmh3_ch datapoints: 100000 msecs: 328
 fast-aggregated-hashing  replication_factor: 4 diverse_replicas: 0 n_destinations: 48    hash_type: mmh3_ch datapoints: 100000 msecs: 320
```
  