### PR TITLE
Fix leaks in writeForever and writeTagsForever

### DIFF
--- a/lib/carbon/writer.py
+++ b/lib/carbon/writer.py
@@ -183,10 +183,11 @@ def writeCachedDataPoints():
             pointCount, metric, updateTime))
 
 
+@inlineCallbacks
 def writeForever():
   while reactor.running:
     try:
-      writeCachedDataPoints()
+      yield writeCachedDataPoints()
     except Exception:
       log.err()
       # Back-off on error to give the backend time to recover.
@@ -205,10 +206,11 @@ def writeTags():
     yield state.database.tag(*tags)
 
 
+@inlineCallbacks
 def writeTagsForever():
   while reactor.running:
     try:
-      writeTags()
+      yield writeTags()
     except Exception:
       log.err()
       # Back-off on error to give the backend time to recover.


### PR DESCRIPTION
`writeCachedDataPoints` will return a `Deferred` before it's finished executing (most noticeable if it needs to wait for a token from `CREATE_BUCKET` or `UPDATE_BUCKET`), so ignoring the return value before calling it again can result in lots of overlapping calls.

I have the `writeForever` patch running on a live system for about an hour, and it has fixed both #729 and #730 (which were both caused by lots of calls taking data from the cache but having to wait to write it to disk because of `MAX_UPDATES_PER_SECOND`).

We have tags disabled, so I'm not certain that `writeTags` has the same leak: I think it'd be fine if it never takes more than 0.2s (the sleep in `writeTagsForever`). I don't know if this is the case or not.