### PR TITLE
[1.1.x] Fix leaks in writeForever and writeTagsForever

### DIFF
--- a/lib/carbon/writer.py
+++ b/lib/carbon/writer.py
@@ -183,10 +183,11 @@ def writeCachedDataPoints():
             pointCount, metric, updateTime))
 
 
+@inlineCallbacks
 def writeForever():
   while reactor.running:
     try:
-      writeCachedDataPoints()
+      yield writeCachedDataPoints()
     except Exception:
       log.err()
       # Back-off on error to give the backend time to recover.
@@ -205,10 +206,11 @@ def writeTags():
     yield state.database.tag(*tags)
 
 
+@inlineCallbacks
 def writeTagsForever():
   while reactor.running:
     try:
-      writeTags()
+      yield writeTags()
     except Exception:
       log.err()
       # Back-off on error to give the backend time to recover.


### PR DESCRIPTION
Backports the following commits to 1.1.x:
 - Fix leaks in writeForever and writeTagsForever (#733)