### PR TITLE
writers run synchronously in separate threads

### DIFF
--- a/lib/carbon/database.py
+++ b/lib/carbon/database.py
@@ -65,18 +65,14 @@ class TimeSeriesDatabase(with_metaclass(PluginRegistrar, object)):
     log.debug("Tagging %s" % ', '.join(metrics), type='tagdb')
     t = time.time()
 
-    def successHandler(result, *args, **kw):
+    try:
+      httpRequest(
+        self.graphite_url + '/tags/tagMultiSeries',
+        [('path', metric) for metric in metrics]
+      )
       log.debug("Tagged %s in %s" % (', '.join(metrics), time.time() - t), type='tagdb')
-      return True
-
-    def errorHandler(err):
-      log.msg("Error tagging %s: %s" % (', '.join(metrics), err.getErrorMessage()), type='tagdb')
-      return err
-
-    return httpRequest(
-      self.graphite_url + '/tags/tagMultiSeries',
-      [('path', metric) for metric in metrics]
-    ).addCallback(successHandler).addErrback(errorHandler)
+    except Exception as err:
+      log.msg("Error tagging %s: %s" % (', '.join(metrics), err), type='tagdb')
 
 
 try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Twisted>=13.2.0
 git+git://github.com/graphite-project/whisper.git#egg=whisper
 txAMQP
 cachetools
+urllib3

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ try:
         scripts=glob('bin/*'),
         package_data={ 'carbon' : ['*.xml'] },
         data_files=install_files,
-        install_requires=['Twisted', 'txAMQP', 'cachetools'],
+        install_requires=['Twisted', 'txAMQP', 'cachetools', 'urllib3'],
         classifiers=(
             'Intended Audience :: Developers',
             'Natural Language :: English',


### PR DESCRIPTION
This PR removes the async code from the writers, which now run synchronously in their own threads.  This should alleviate issues caused by mixing code that runs in the main thread with workers running in separate threads.

It does add a dependency on `urllib3` since we're no longer using the twisted http library.