### PR TITLE
[1.1.x] carbon line format float handling

### DIFF
--- a/lib/carbon/client.py
+++ b/lib/carbon/client.py
@@ -415,7 +415,11 @@ class CarbonLineClientProtocol(CarbonClientProtocol, LineOnlyReceiver):
 
   def _sendDatapointsNow(self, datapoints):
     for metric, datapoint in datapoints:
-        self.sendLine("%s %f %d" % (metric, datapoint[1], datapoint[0]))
+      if isinstance(datapoint[1], float):
+        value = ("%.10f" % datapoint[1]).rstrip('0').rstrip('.')
+      else:
+        value = "%d" % datapoint[1]
+      self.sendLine("%s %s %d" % (metric, value, datapoint[0]))
 
 
 class CarbonLineClientFactory(CarbonClientFactory):

--- a/lib/carbon/tests/test_client.py
+++ b/lib/carbon/tests/test_client.py
@@ -70,12 +70,22 @@ class CarbonLineClientProtocolTest(TestCase):
     self.protocol = CarbonLineClientProtocol()
     self.protocol.sendLine = Mock()
 
-  def test_send_datapoints_now(self):
-    datapoint = ('foo.bar', (1000000000, 1.0))
-    expected_line_to_send = "foo.bar 1.000000 1000000000"
+  def test_send_datapoints(self):
+    calls = [
+      (('foo.bar', (1000000000, 1.0)), "foo.bar 1 1000000000"),
+      (('foo.bar', (1000000000, 1.1)), "foo.bar 1.1 1000000000"),
+      (('foo.bar', (1000000000, 1.123456789123)), "foo.bar 1.1234567891 1000000000"),
+      (('foo.bar', (1000000000, 1)), "foo.bar 1 1000000000"),
+      (('foo.bar', (1000000000, 1.498566361088E12)), "foo.bar 1498566361088 1000000000"),
+    ]
 
-    self.protocol._sendDatapointsNow([datapoint])
-    self.protocol.sendLine.assert_called_once_with(expected_line_to_send)
+    i = 0
+    for (datapoint, expected_line_to_send) in calls:
+      i += 1
+
+      self.protocol._sendDatapointsNow([datapoint])
+      self.assertEqual(self.protocol.sendLine.call_count, i)
+      self.protocol.sendLine.assert_called_with(expected_line_to_send)
 
 
 @patch('carbon.state.instrumentation', Mock(spec=instrumentation))


### PR DESCRIPTION
Backports the following commits to 1.1.x:
 - carbon line format float handling (#740)