### PR TITLE
[1.1.x] add percentile aggregation methods | tests for percentile aggregation methods | Fix linting errors

### DIFF
--- a/lib/carbon/aggregator/rules.py
+++ b/lib/carbon/aggregator/rules.py
@@ -161,6 +161,7 @@ def count(values):
   if values:
     return len(values)
 
+
 def percentile(factor):
   def func(values):
     if values:
@@ -177,18 +178,18 @@ def percentile(factor):
   return func
 
 AGGREGATION_METHODS = {
-  'sum'   : sum,
-  'avg'   : avg,
-  'min'   : min,
-  'max'   : max,
-  'p50'   : percentile(0.50),
-  'p75'   : percentile(0.75),
-  'p80'   : percentile(0.80),
-  'p90'   : percentile(0.90),
-  'p95'   : percentile(0.95),
-  'p99'   : percentile(0.99),
-  'p999'  : percentile(0.999),
-  'count' : count
+  'sum': sum,
+  'avg': avg,
+  'min': min,
+  'max': max,
+  'p50': percentile(0.50),
+  'p75': percentile(0.75),
+  'p80': percentile(0.80),
+  'p90': percentile(0.90),
+  'p95': percentile(0.95),
+  'p99': percentile(0.99),
+  'p999': percentile(0.999),
+  'count': count,
 }
 
 # Importable singleton

--- a/lib/carbon/aggregator/rules.py
+++ b/lib/carbon/aggregator/rules.py
@@ -1,5 +1,7 @@
 import re
 
+from math import floor, ceil
+
 from os.path import exists, getmtime
 from twisted.internet.task import LoopingCall
 from cachetools import TTLCache, LRUCache
@@ -159,12 +161,34 @@ def count(values):
   if values:
     return len(values)
 
+def percentile(factor):
+  def func(values):
+    if values:
+      values = sorted(values)
+      rank = factor * (len(values) - 1)
+      rank_left = int(floor(rank))
+      rank_right = int(ceil(rank))
+
+      if rank_left == rank_right:
+        return values[rank_left]
+      else:
+        return values[rank_left] * (rank_right - rank) + values[rank_right] * (rank - rank_left)
+
+  return func
+
 AGGREGATION_METHODS = {
-  'sum': sum,
-  'avg': avg,
-  'min': min,
-  'max': max,
-  'count': count
+  'sum'   : sum,
+  'avg'   : avg,
+  'min'   : min,
+  'max'   : max,
+  'p50'   : percentile(0.50),
+  'p75'   : percentile(0.75),
+  'p80'   : percentile(0.80),
+  'p90'   : percentile(0.90),
+  'p95'   : percentile(0.95),
+  'p99'   : percentile(0.99),
+  'p999'  : percentile(0.999),
+  'count' : count
 }
 
 # Importable singleton

--- a/lib/carbon/tests/test_aggregator_methods.py
+++ b/lib/carbon/tests/test_aggregator_methods.py
@@ -1,0 +1,37 @@
+import unittest
+
+from carbon.aggregator.rules import AGGREGATION_METHODS
+
+PERCENTILE_METHODS = [ 'p999', 'p99', 'p95', 'p90', 'p80', 'p75', 'p50']
+VALUES = [4, 8, 15, 16, 23, 42]
+
+
+def almost_equal(a, b):
+    return abs(a - b) < 0.0000000001
+
+
+class AggregationMethodTest(unittest.TestCase):
+    def test_percentile_simple(self):
+        for method in PERCENTILE_METHODS:
+            self.assertTrue(almost_equal(AGGREGATION_METHODS[method]([1]), 1))
+
+    def test_percentile_order(self):
+        for method in PERCENTILE_METHODS:
+            a = AGGREGATION_METHODS[method]([1,2,3,4,5])
+            b = AGGREGATION_METHODS[method]([3,2,1,4,5])
+            self.assertTrue(almost_equal(a, b))
+
+    def test_percentile_values(self):
+        examples = [
+            ('p999', 41.905, ),
+            ('p99', 41.05, ),
+            ('p95', 37.25, ),
+            ('p90', 32.5, ),
+            ('p80', 23, ),
+            ('p75', 21.25, ),
+            ('p50', 15.5, ),
+        ]
+
+        for (method, result) in examples:
+            self.assertTrue(almost_equal(AGGREGATION_METHODS[method](VALUES), result))
+

--- a/lib/carbon/tests/test_aggregator_methods.py
+++ b/lib/carbon/tests/test_aggregator_methods.py
@@ -2,7 +2,7 @@ import unittest
 
 from carbon.aggregator.rules import AGGREGATION_METHODS
 
-PERCENTILE_METHODS = [ 'p999', 'p99', 'p95', 'p90', 'p80', 'p75', 'p50']
+PERCENTILE_METHODS = ['p999', 'p99', 'p95', 'p90', 'p80', 'p75', 'p50']
 VALUES = [4, 8, 15, 16, 23, 42]
 
 
@@ -17,8 +17,8 @@ class AggregationMethodTest(unittest.TestCase):
 
     def test_percentile_order(self):
         for method in PERCENTILE_METHODS:
-            a = AGGREGATION_METHODS[method]([1,2,3,4,5])
-            b = AGGREGATION_METHODS[method]([3,2,1,4,5])
+            a = AGGREGATION_METHODS[method]([1, 2, 3, 4, 5])
+            b = AGGREGATION_METHODS[method]([3, 2, 1, 4, 5])
             self.assertTrue(almost_equal(a, b))
 
     def test_percentile_values(self):
@@ -34,4 +34,3 @@ class AggregationMethodTest(unittest.TestCase):
 
         for (method, result) in examples:
             self.assertTrue(almost_equal(AGGREGATION_METHODS[method](VALUES), result))
-


### PR DESCRIPTION
Backports the following commits to 1.1.x:
 - add percentile aggregation methods (#696)
 - tests for percentile aggregation methods (#696)
 - Fix linting errors (#696)