### PR TITLE
Adding dummy.txt to storage dirs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,9 +58,9 @@ else:
   setup_kwargs = dict()
 
 
-storage_dirs = [ ('storage/ceres', []), ('storage/whisper',[]),
-                 ('storage/lists',[]), ('storage/log',[]),
-                 ('storage/rrd',[]) ]
+storage_dirs = [ ('storage/ceres/dummy.txt', []), ('storage/whisper/dummy.txt',[]),
+                 ('storage/lists',[]), ('storage/log/dummy.txt',[]),
+                 ('storage/rrd/dummy.txt',[]) ]
 conf_files = [ ('conf', glob('conf/*.example')) ]
 
 install_files = storage_dirs + conf_files


### PR DESCRIPTION
Fixing https://github.com/graphite-project/carbon/issues/711
Also, upgrade manual for next release should include instructions to remove all /opt/graphite/storage entries from /opt/graphite/lib/carbon-x.x.x-pyx.x.egg-info/installed-files.txt file before the upgrade.