### PR TITLE
Don't leak file descriptors in instrumentation

### DIFF
--- a/lib/carbon/instrumentation.py
+++ b/lib/carbon/instrumentation.py
@@ -68,7 +68,8 @@ def getCpuUsage():
 
 
 def getMemUsage():
-  rss_pages = int(open('/proc/self/statm').read().split()[1])
+  with open('/proc/self/statm') as statm:
+    rss_pages = int(statm.read().split()[1])
   return rss_pages * PAGESIZE
 
 

--- a/lib/carbon/tests/test_instrumentation.py
+++ b/lib/carbon/tests/test_instrumentation.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+import os
+import sys
+from unittest import TestCase
+
+from mock import mock_open, patch, call
+
+from carbon.instrumentation import getMemUsage
+
+
+class TestInstrumentation(TestCase):
+
+    def test_getMemUsage(self):
+        if sys.version_info[0] >= 3:
+            open_call = 'builtins.open'
+        else:
+            open_call = '__builtin__.open'
+
+        with patch(open_call, mock_open(read_data='1 2 1 1 0 1 0')) as m:
+            page_size = os.sysconf('SC_PAGESIZE')
+            usage = getMemUsage()
+            m.assert_has_calls([call().__exit__(None, None, None)],
+                               any_order=True)
+            self.assertEqual(usage, 2 * page_size)


### PR DESCRIPTION
Whenever getMemUsage was called we could leak a file descriptor
to /stat/self/statm. Ensure we close it now and in the future.