### PR TITLE
Fix logging on py3 Twisted > 16

### DIFF
--- a/lib/carbon/log.py
+++ b/lib/carbon/log.py
@@ -21,7 +21,7 @@ class CarbonLogFile(DailyLogFile):
     """
     openMode = self.defaultMode or 0o777
     self._file = os.fdopen(os.open(
-      self.path, os.O_CREAT | os.O_RDWR, openMode), 'r+', 1)
+      self.path, os.O_CREAT | os.O_RDWR, openMode), 'rb+', 1)
     self.closed = False
     # Try our best to update permissions for files which already exist.
     if self.defaultMode:

--- a/lib/carbon/tests/test_log.py
+++ b/lib/carbon/tests/test_log.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+from unittest import TestCase
+from os import path
+from twisted.python.log import addObserver, removeObserver
+from carbon import log
+
+try:
+    from tempfile import TemporaryDirectory
+except ImportError:
+    from backports.tempfile import TemporaryDirectory
+
+
+class CarbonLogFileTest(TestCase):
+
+    def test_write_to_logfile(self):
+        with TemporaryDirectory() as tmpdir:
+            o = log.CarbonLogObserver()
+            o.log_to_dir(tmpdir)
+            addObserver(o)
+            log.creates('😀😀😀😀 test !!!!')
+            removeObserver(o)
+
+            with open(path.join(tmpdir, 'creates.log')) as logfile:
+                read_line = logfile.readline()
+                self.assertRegexpMatches(read_line, '.*😀😀😀😀 test !!!!')

--- a/tests-requirements.txt
+++ b/tests-requirements.txt
@@ -5,3 +5,4 @@ nose
 protobuf
 mmh3
 git+git://github.com/graphite-project/ceres.git#egg=ceres
+backports.tempfile


### PR DESCRIPTION
fixes #749, fixes #765 

We should probably move to the new Twisted logging API, but this fixes it for now.