### PR TITLE
rewrite is handled in pipeline now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # http://travis-ci.org/#!/graphite-project/carbon
 language: python
 python: 2.7
+# sudo is needed to install libboost-python-dev, which is required by pyhash
 sudo: required
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # http://travis-ci.org/#!/graphite-project/carbon
 language: python
 python: 2.7
-sudo: false
+sudo: required
 
 matrix:
   include:

--- a/lib/carbon/aggregator/processor.py
+++ b/lib/carbon/aggregator/processor.py
@@ -2,7 +2,6 @@ from carbon.aggregator.rules import RuleManager
 from carbon.aggregator.buffers import BufferManager
 from carbon.instrumentation import increment
 from carbon.pipeline import Processor
-from carbon.rewrite import PRE, POST, RewriteRuleManager
 from carbon.conf import settings
 from carbon import log
 
@@ -12,9 +11,6 @@ class AggregationProcessor(Processor):
 
   def process(self, metric, datapoint):
     increment('datapointsReceived')
-
-    for rule in RewriteRuleManager.rules(PRE):
-      metric = rule.apply(metric)
 
     aggregate_metrics = set()
 
@@ -32,9 +28,6 @@ class AggregationProcessor(Processor):
         values_buffer.configure_aggregation(rule.frequency, rule.aggregation_func)
 
       values_buffer.input(datapoint)
-
-    for rule in RewriteRuleManager.rules(POST):
-      metric = rule.apply(metric)
 
     if settings.FORWARD_ALL and metric not in aggregate_metrics:
       if settings.LOG_AGGREGATOR_MISSES and len(aggregate_metrics) == 0:

--- a/lib/carbon/tests/test_aggregator_processor.py
+++ b/lib/carbon/tests/test_aggregator_processor.py
@@ -1,8 +1,7 @@
-from mock import call, Mock, patch
+from mock import patch
 from unittest import TestCase
 
 from carbon import instrumentation
-from carbon.rewrite import PRE, POST, RewriteRule, RewriteRuleManager
 from carbon.pipeline import Processor
 from carbon.aggregator.buffers import BufferManager
 from carbon.aggregator.rules import AggregationRule, RuleManager
@@ -11,7 +10,6 @@ from carbon.aggregator.processor import AggregationProcessor
 
 class AggregationProcessorTest(TestCase):
   def setUp(self):
-    self.sample_rewrite_rule = RewriteRule(r'^(carbon.foo)', r'\1.bar')
     self.sample_aggregation_rule = AggregationRule(r'^carbon.foo', r'carbon.foo.sum', 'sum', 1)
     self.sample_overwriting_aggregation_rule = \
         AggregationRule(r'^carbon.foo', r'carbon.foo', 'sum', 1)
@@ -21,7 +19,6 @@ class AggregationProcessorTest(TestCase):
     instrumentation.stats.clear()
     BufferManager.clear()
     RuleManager.clear()
-    RewriteRuleManager.clear()
 
   def test_registers_plugin(self):
     self.assertTrue('aggregate' in Processor.plugins)
@@ -29,16 +26,6 @@ class AggregationProcessorTest(TestCase):
   def test_process_increments_datapoints_metric(self):
     list(self.processor.process('carbon.foo', (0, 0)))
     self.assertEqual(1, instrumentation.stats['datapointsReceived'])
-
-  def test_pre_rules_applied(self):
-    RewriteRuleManager.rulesets[PRE] = [self.sample_rewrite_rule]
-    result = list(self.processor.process('carbon.foo', (0, 0)))
-    self.assertEqual('carbon.foo.bar', result[0][0])
-
-  def test_post_rules_applied(self):
-    RewriteRuleManager.rulesets[POST] = [self.sample_rewrite_rule]
-    result = list(self.processor.process('carbon.foo', (0, 0)))
-    self.assertEqual('carbon.foo.bar', result[0][0])
 
   def test_unaggregated_metrics_pass_through_when_no_rules(self):
     result = list(self.processor.process('carbon.foo', (0, 0)))
@@ -54,40 +41,6 @@ class AggregationProcessorTest(TestCase):
     with patch.object(self.sample_aggregation_rule, 'get_aggregate_metric'):
       list(self.processor.process('carbon.foo', (0, 0)))
       self.sample_aggregation_rule.get_aggregate_metric.assert_called_once_with('carbon.foo')
-
-  def test_pre_rewrite_then_aggregation_rule(self):
-    RewriteRuleManager.rulesets[PRE] = [self.sample_rewrite_rule]
-    RuleManager.rules = [self.sample_aggregation_rule]
-    apply_mock = Mock(side_effect=['carbon.foo.rewrite', 'carbon.foo.rewrite.aggregate'])
-
-    with patch.object(self.sample_rewrite_rule, 'apply', apply_mock):
-      with patch.object(self.sample_aggregation_rule, 'get_aggregate_metric', apply_mock):
-        list(self.processor.process('carbon.foo', (0, 0)))
-
-    # Pre rewrite gets metric as passed in and transforms before aggregation rule called
-    self.assertEqual([call('carbon.foo'), call('carbon.foo.rewrite')], apply_mock.call_args_list)
-
-  def test_aggregation_rule_then_post_rewrite(self):
-    RuleManager.rules = [self.sample_aggregation_rule]
-    RewriteRuleManager.rulesets[POST] = [self.sample_rewrite_rule]
-    apply_mock = Mock(side_effect=['carbon.foo.aggregate', 'carbon.foo.aggregate.rewrite'])
-
-    with patch.object(self.sample_rewrite_rule, 'apply', apply_mock):
-      with patch.object(self.sample_aggregation_rule, 'get_aggregate_metric', apply_mock):
-        list(self.processor.process('carbon.foo', (0, 0)))
-    # Aggregation rule gets metric as passed in and so does post rewrite (due to no pre)
-    self.assertEqual([call('carbon.foo'), call('carbon.foo')], apply_mock.call_args_list)
-
-  def test_pre_rewrite_then_post_rewrite(self):
-    RewriteRuleManager.rulesets[PRE] = [self.sample_rewrite_rule]
-    RewriteRuleManager.rulesets[POST] = [self.sample_rewrite_rule]
-    apply_mock = Mock(side_effect=['carbon.foo.rewrite', 'carbon.foo.rewrite.rewrite'])
-
-    with patch.object(self.sample_rewrite_rule, 'apply', apply_mock):
-      list(self.processor.process('carbon.foo', (0, 0)))
-
-    # Pre rewrite gets metric as passed in and transforms before post rewrite called
-    self.assertEqual([call('carbon.foo'), call('carbon.foo.rewrite')], apply_mock.call_args_list)
 
   def test_new_buffer_configured(self):
     RuleManager.rules = [self.sample_aggregation_rule]


### PR DESCRIPTION
This expands #677 by also removing the outdated tests and no-longer-needed imports.

Resolves #676