### PR TITLE
aggregator: hide "Allocating new metric"

### DIFF
--- a/lib/carbon/aggregator/buffers.py
+++ b/lib/carbon/aggregator/buffers.py
@@ -13,7 +13,7 @@ class _BufferManager:
 
   def get_buffer(self, metric_path):
     if metric_path not in self.buffers:
-      log.aggregator("Allocating new metric buffer for %s" % metric_path)
+      log.debug("Allocating new metric buffer for %s" % metric_path)
       self.buffers[metric_path] = MetricBuffer(metric_path)
 
     return self.buffers[metric_path]


### PR DESCRIPTION
This is useless and bloats the logs, move it to
debug.