### PR TITLE
[1.1.x] import setUpRandomResolver only for new Twisted | Keeping it simple | spacing | Taming E501 in linter

### DIFF
--- a/lib/carbon/client.py
+++ b/lib/carbon/client.py
@@ -12,7 +12,6 @@ from carbon.conf import settings
 from carbon.util import pickle
 from carbon.util import PluginRegistrar
 from carbon.util import enableTcpKeepAlive
-from carbon.resolver import setUpRandomResolver
 from carbon import instrumentation, log, pipeline, state
 
 try:
@@ -28,6 +27,17 @@ try:
     import signal
 except ImportError:
     log.debug("Couldn't import signal module")
+
+try:
+  import twisted as _twisted
+  twisted_version = tuple(map(int, getattr(_twisted, '__version__', '0').split('.')))
+  if twisted_version >= (17, 1):
+    from carbon.resolver import setUpRandomResolver
+  else:
+    setUpRandomResolver = None
+  del _twisted
+except ImportError:
+  setUpRandomResolver = None
 
 
 SEND_QUEUE_LOW_WATERMARK = settings.MAX_QUEUE_SIZE * settings.QUEUE_LOW_WATERMARK_PCT
@@ -528,7 +538,11 @@ class CarbonClientManager(Service):
         # If we decide to open multiple TCP connection to a replica, we probably
         # want to try to also load-balance accross hosts. In this case we need
         # to make sure rfc3484 doesn't get in the way.
-        setUpRandomResolver(reactor)
+        if setUpRandomResolver:
+          setUpRandomResolver(reactor)
+        else:
+          print("You need Twisted >= 17.1.0 for using DESTINATION_POOL_REPLICAS.")
+          raise SystemExit(1)
 
     self.router = router
     self.client_factories = {}  # { destination : CarbonClientFactory() }

--- a/lib/carbon/client.py
+++ b/lib/carbon/client.py
@@ -535,7 +535,7 @@ class CarbonClientManager(Service):
         if setUpRandomResolver:
           setUpRandomResolver(reactor)
         else:
-          print("Import error, you probably need Twisted >= 17.1.0 for using DESTINATION_POOL_REPLICAS.")
+          print("Import error, Twisted >= 17.1.0 needed for using DESTINATION_POOL_REPLICAS.")
           raise SystemExit(1)
 
     self.router = router

--- a/lib/carbon/client.py
+++ b/lib/carbon/client.py
@@ -29,13 +29,7 @@ except ImportError:
     log.debug("Couldn't import signal module")
 
 try:
-  import twisted as _twisted
-  twisted_version = tuple(map(int, getattr(_twisted, '__version__', '0').split('.')))
-  if twisted_version >= (17, 1):
     from carbon.resolver import setUpRandomResolver
-  else:
-    setUpRandomResolver = None
-  del _twisted
 except ImportError:
   setUpRandomResolver = None
 
@@ -541,7 +535,7 @@ class CarbonClientManager(Service):
         if setUpRandomResolver:
           setUpRandomResolver(reactor)
         else:
-          print("You need Twisted >= 17.1.0 for using DESTINATION_POOL_REPLICAS.")
+          print("Import error, you probably need Twisted >= 17.1.0 for using DESTINATION_POOL_REPLICAS.")
           raise SystemExit(1)
 
     self.router = router

--- a/lib/carbon/client.py
+++ b/lib/carbon/client.py
@@ -31,7 +31,7 @@ except ImportError:
 try:
     from carbon.resolver import setUpRandomResolver
 except ImportError:
-  setUpRandomResolver = None
+    setUpRandomResolver = None
 
 
 SEND_QUEUE_LOW_WATERMARK = settings.MAX_QUEUE_SIZE * settings.QUEUE_LOW_WATERMARK_PCT


### PR DESCRIPTION
Backports the following commits to 1.1.x:
 - import setUpRandomResolver only for new Twisted (#806)
 - Keeping it simple (#806)
 - spacing (#806)
 - Taming E501 in linter (#808)