### PR TITLE
[DISCUSS] release threads between writer runs

### DIFF
--- a/lib/carbon/writer.py
+++ b/lib/carbon/writer.py
@@ -186,7 +186,7 @@ def writeCachedDataPoints():
 def writeForever():
   def handleOk(result):
     # Avoid churning CPU when there are no series in the queue
-    reactor.callLater(1, writeForever)
+    reactor.callLater(0.2, writeForever)
 
   def handleErr(err):
     log.msg('Error writing data points: %s' % err)
@@ -207,7 +207,7 @@ def writeTags():
 def writeTagsForever():
   def handleOk(result):
     # Avoid churning CPU when there are no series in the queue
-    reactor.callLater(1, writeTagsForever)
+    reactor.callLater(0.2, writeTagsForever)
 
   def handleErr(err):
     log.msg('Error writing tags: %s' % err)


### PR DESCRIPTION
I have received a report of the writer thread stopping, which results in the metric cache growing and nothing being written to disk.

I'm not sure what the underlying cause is, though it's possible that accessing `reactor.running` from the background thread is part of the issue.  I also noted that when the thread calls `time.sleep()` between runs it is blocking for no good reason.

This PR modified the `writeForever` and `writeTagsForever` functions to run as regular twisted async functions, using `reactor.callLater()` to schedule their next run, and `threads.deferToThread` to call `writeCachedDataPoints` and `writeTags` in threads from the twisted threadpool.  This avoids the need to access `reactor` from those threads, and leaves scheduling in the main thread.

The only behavior change this should introduce is that I set the wait time after draining the queue to 1s for `writeTagsForever` to match `writeForever`, though I do wonder whether it would make more sense to shorten that.

I have not yet done any load testing on this, and would appreciate any feedback.