### PR TITLE
Update default storage schema in storage-schemas.conf.example

### DIFF
--- a/conf/storage-schemas.conf.example
+++ b/conf/storage-schemas.conf.example
@@ -29,6 +29,6 @@
 pattern = ^carbon\.
 retentions = 60:90d
 
-[default_1min_for_1day]
+[default]
 pattern = .*
 retentions = 60s:1d,5m:30d,1h:3y

--- a/conf/storage-schemas.conf.example
+++ b/conf/storage-schemas.conf.example
@@ -7,6 +7,11 @@
 #    pattern = regex
 #    retentions = timePerPoint:timeToStore, timePerPoint:timeToStore, ...
 #
+# name: Arbitrary unique name for the rule
+# pattern: Regular expression to match against the metric name. For syntax see:
+#          https://docs.python.org/3/library/re.html#regular-expression-syntax
+# retentions: Retention schema for the metric
+#
 # Remember: To support accurate aggregation from higher to lower resolution
 #           archives, the precision of a longer retention archive must be
 #           cleanly divisible by precision of next lower retention archive.
@@ -26,4 +31,4 @@ retentions = 60:90d
 
 [default_1min_for_1day]
 pattern = .*
-retentions = 60s:1d
+retentions = 60s:1d,5m:30d,1h:3y


### PR DESCRIPTION
resolves #823 

I'm not sure about this. Might be better for users to realize they have to configure a storage schema after a day instead of realizing a year later that the default does not suite them. On the other hand, questions about data disappearing come after a day come up way to often on Stack Overflow and Launchpad Questions and Github Issues. Also, I have no clue what a sane default should be.