### PR TITLE
Fix carbon cache locking

### DIFF
--- a/lib/carbon/cache.py
+++ b/lib/carbon/cache.py
@@ -158,16 +158,14 @@ class _MetricCache(defaultdict):
 
   @property
   def counts(self):
-    with self.lock:
-      return [(metric, len(datapoints)) for (metric, datapoints)
-              in self.items()]
+    return [(metric, len(datapoints)) for (metric, datapoints)
+            in self.items()]
 
   @property
   def watermarks(self):
-    with self.lock:
-      return [(metric, min(datapoints.keys()), max(datapoints.keys()))
-              for (metric, datapoints) in self.items()
-              if datapoints]
+    return [(metric, min(datapoints.keys()), max(datapoints.keys()))
+            for (metric, datapoints) in self.items()
+            if datapoints]
 
   @property
   def is_full(self):
@@ -187,7 +185,8 @@ class _MetricCache(defaultdict):
     if not self:
       return (None, [])
     if self.strategy:
-      metric = self.strategy.choose_item()
+      with self.lock:
+        metric = self.strategy.choose_item()
     else:
       # Avoid .keys() as it dumps the whole list
       metric = next(iter(self))
@@ -209,18 +208,18 @@ class _MetricCache(defaultdict):
 
   def store(self, metric, datapoint):
     timestamp, value = datapoint
-    if timestamp not in self[metric]:
-      # Not a duplicate, hence process if cache is not full
-      if self.is_full:
-        log.msg("MetricCache is full: self.size=%d" % self.size)
-        events.cacheFull()
-      else:
-        with self.lock:
+    with self.lock:
+      if timestamp not in self[metric]:
+        # Not a duplicate, hence process if cache is not full
+        if self.is_full:
+          log.msg("MetricCache is full: self.size=%d" % self.size)
+          events.cacheFull()
+        else:
           self.size += 1
           self[metric][timestamp] = value
-    else:
-      # Updating a duplicate does not increase the cache size
-      self[metric][timestamp] = value
+      else:
+        # Updating a duplicate does not increase the cache size
+        self[metric][timestamp] = value
 
 
 _Cache = None


### PR DESCRIPTION
Add lock when calling choose_item(), this seemed to cause the issues in #822 #815.
Remove previously added locks to counts and watermarks as they deadlocked with
the new lock.
Improve locking in store(), it would lock _after_ checking if the timestamp is in
the cache. The cache could have been altered between checking and locking.