### PR TITLE
Remove /opt/graphite prefix and use setuptools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ storage
 _trial_temp
 htmlcov
 *.swp
+lib/twisted/plugins/dropin.cache
+lib/carbon.egg-info/

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ storage
 _trial_temp
 htmlcov
 *.swp
-lib/twisted/plugins/dropin.cache
 .eggs/
 *.egg-info/
 lib/twisted/plugins/dropin.cache

--- a/bin/carbon-aggregator-cache.py
+++ b/bin/carbon-aggregator-cache.py
@@ -13,18 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License."""
 
-import sys
-import os.path
-
-# Figure out where we're installed
-BIN_DIR = os.path.dirname(os.path.abspath(__file__))
-ROOT_DIR = os.path.dirname(BIN_DIR)
-
-# Make sure that carbon's 'lib' dir is in the $PYTHONPATH if we're running from
-# source.
-LIB_DIR = os.path.join(ROOT_DIR, "lib")
-sys.path.insert(0, LIB_DIR)
-
 from carbon.util import run_twistd_plugin  # noqa
 from carbon.exceptions import CarbonConfigException  # noqa
 

--- a/bin/carbon-aggregator.py
+++ b/bin/carbon-aggregator.py
@@ -13,18 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License."""
 
-import sys
-import os.path
-
-# Figure out where we're installed
-BIN_DIR = os.path.dirname(os.path.abspath(__file__))
-ROOT_DIR = os.path.dirname(BIN_DIR)
-
-# Make sure that carbon's 'lib' dir is in the $PYTHONPATH if we're running from
-# source.
-LIB_DIR = os.path.join(ROOT_DIR, "lib")
-sys.path.insert(0, LIB_DIR)
-
 from carbon.util import run_twistd_plugin  # noqa
 from carbon.exceptions import CarbonConfigException  # noqa
 

--- a/bin/carbon-cache.py
+++ b/bin/carbon-cache.py
@@ -13,18 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License."""
 
-import sys
-import os.path
-
-# Figure out where we're installed
-BIN_DIR = os.path.dirname(os.path.abspath(__file__))
-ROOT_DIR = os.path.dirname(BIN_DIR)
-
-# Make sure that carbon's 'lib' dir is in the $PYTHONPATH if we're running from
-# source.
-LIB_DIR = os.path.join(ROOT_DIR, "lib")
-sys.path.insert(0, LIB_DIR)
-
 from carbon.util import run_twistd_plugin  # noqa
 from carbon.exceptions import CarbonConfigException  # noqa
 

--- a/bin/carbon-client.py
+++ b/bin/carbon-client.py
@@ -29,7 +29,6 @@ from carbon.routers import ConsistentHashingRouter, RelayRulesRouter  # noqa
 from carbon.client import CarbonClientManager  # noqa
 from carbon import log, events  # noqa
 
-CONF_DIR = join(sys.prefix, 'conf')
 default_relayrules = join('/opt/graphite', 'relay-rules.conf')
 
 option_parser = OptionParser(usage="%prog [options] <host:port:instance> <host:port:instance> ...")

--- a/bin/carbon-client.py
+++ b/bin/carbon-client.py
@@ -14,19 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License."""
 
 import sys
-from os.path import dirname, join, abspath, exists
+from os.path import join, exists
 from optparse import OptionParser
 
-# Figure out where we're installed
-BIN_DIR = dirname(abspath(__file__))
-ROOT_DIR = dirname(BIN_DIR)
-CONF_DIR = join(ROOT_DIR, 'conf')
+CONF_DIR = join(sys.prefix, 'conf')
 default_relayrules = join(CONF_DIR, 'relay-rules.conf')
-
-# Make sure that carbon's 'lib' dir is in the $PYTHONPATH if we're running from
-# source.
-LIB_DIR = join(ROOT_DIR, 'lib')
-sys.path.insert(0, LIB_DIR)
 
 try:
   from twisted.internet import epollreactor

--- a/bin/carbon-client.py
+++ b/bin/carbon-client.py
@@ -17,9 +17,6 @@ import sys
 from os.path import join, exists
 from optparse import OptionParser
 
-CONF_DIR = join(sys.prefix, 'conf')
-default_relayrules = join(CONF_DIR, 'relay-rules.conf')
-
 try:
   from twisted.internet import epollreactor
   epollreactor.install()
@@ -32,6 +29,8 @@ from carbon.routers import ConsistentHashingRouter, RelayRulesRouter  # noqa
 from carbon.client import CarbonClientManager  # noqa
 from carbon import log, events  # noqa
 
+CONF_DIR = join(sys.prefix, 'conf')
+default_relayrules = join('/opt/graphite', 'relay-rules.conf')
 
 option_parser = OptionParser(usage="%prog [options] <host:port:instance> <host:port:instance> ...")
 option_parser.add_option('--debug', action='store_true', help="Log debug info to stdout")

--- a/bin/carbon-client.py
+++ b/bin/carbon-client.py
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License."""
 
-import sys
 from os.path import join, exists
 from optparse import OptionParser
 

--- a/bin/carbon-relay.py
+++ b/bin/carbon-relay.py
@@ -13,18 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License."""
 
-import sys
-import os.path
-
-# Figure out where we're installed
-BIN_DIR = os.path.dirname(os.path.abspath(__file__))
-ROOT_DIR = os.path.dirname(BIN_DIR)
-
-# Make sure that carbon's 'lib' dir is in the $PYTHONPATH if we're running from
-# source.
-LIB_DIR = os.path.join(ROOT_DIR, "lib")
-sys.path.insert(0, LIB_DIR)
-
 from carbon.util import run_twistd_plugin  # noqa
 from carbon.exceptions import CarbonConfigException  # noqa
 

--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -603,7 +603,7 @@ def read_config(program, options, **kwargs):
     if graphite_root is None:
         graphite_root = os.environ.get('GRAPHITE_ROOT')
     if graphite_root is None:
-        graphite_root = sys.prefix
+        graphite_root = '/opt/graphite'
 
     # Default config directory to root-relative, unless overriden by the
     # 'GRAPHITE_CONF_DIR' environment variable.

--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -583,8 +583,7 @@ def read_config(program, options, **kwargs):
     if graphite_root is None:
         graphite_root = os.environ.get('GRAPHITE_ROOT')
     if graphite_root is None:
-        raise CarbonConfigException("Either ROOT_DIR or GRAPHITE_ROOT "
-                                    "needs to be provided.")
+        graphite_root = sys.prefix
 
     # Default config directory to root-relative, unless overriden by the
     # 'GRAPHITE_CONF_DIR' environment variable.

--- a/lib/carbon/tests/test_conf.py
+++ b/lib/carbon/tests/test_conf.py
@@ -5,7 +5,6 @@ from os import makedirs
 from os.path import dirname, join
 from unittest import TestCase
 from carbon.conf import get_default_parser, parse_options, read_config
-from carbon.exceptions import CarbonConfigException
 
 
 class FakeParser(object):
@@ -100,18 +99,6 @@ class ReadConfigTest(TestCase):
                 f.write(content)
 
         return path
-
-    def test_root_dir_is_required(self):
-        """
-        At minimum, the caller must provide a 'ROOT_DIR' setting.
-        """
-        try:
-            read_config("carbon-foo", FakeOptions(config=None))
-        except CarbonConfigException as e:
-            self.assertEqual("Either ROOT_DIR or GRAPHITE_ROOT "
-                             "needs to be provided.", str(e))
-        else:
-            self.fail("Did not raise exception.")
 
     def test_config_is_not_required(self):
         """

--- a/lib/carbon/util.py
+++ b/lib/carbon/util.py
@@ -9,7 +9,7 @@ except ImportError:
   import __builtin__
 
 from hashlib import sha256
-from os.path import abspath, basename, dirname
+from os.path import basename
 import socket
 from time import sleep, time
 from twisted.python.util import initgroups
@@ -70,10 +70,6 @@ def enableTcpKeepAlive(transport, enable, settings):
 def run_twistd_plugin(filename):
     from carbon.conf import get_parser
     from twisted.scripts.twistd import ServerOptions
-
-    bin_dir = dirname(abspath(filename))
-    root_dir = dirname(bin_dir)
-    os.environ.setdefault('GRAPHITE_ROOT', root_dir)
 
     program = basename(filename).split('.')[0]
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     package_data={'carbon': ['*.xml']},
     data_files=install_files,
     install_requires=['Twisted', 'txAMQP', 'cachetools', 'urllib3'],
-    classifiers=(
+    classifiers=[
         'Intended Audience :: Developers',
         'Natural Language :: English',
         'License :: OSI Approved :: Apache Software License',
@@ -55,6 +55,6 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
-    ),
+    ],
     zip_safe=False
 )

--- a/setup.py
+++ b/setup.py
@@ -1,115 +1,60 @@
 #!/usr/bin/env python
 
-from __future__ import with_statement
-
 import os
 from glob import glob
-try:
-    from ConfigParser import ConfigParser, DuplicateSectionError  # Python 2
-except ImportError:
-    from configparser import ConfigParser, DuplicateSectionError  # Python 3
+from setuptools import setup
 
 
-# Graphite historically has an install prefix set in setup.cfg. Being in a
-# configuration file, it's not easy to override it or unset it (for installing
-# graphite in a virtualenv for instance).
-# The prefix is now set by ``setup.py`` and *unset* if an environment variable
-# named ``GRAPHITE_NO_PREFIX`` is present.
-# While ``setup.cfg`` doesn't contain the prefix anymore, the *unset* step is
-# required for installations from a source tarball because running
-# ``python setup.py sdist`` will re-add the prefix to the tarball's
-# ``setup.cfg``.
-cf = ConfigParser()
-
-with open('setup.cfg', 'r') as f:
-    orig_setup_cfg = f.read()
-    f.seek(0)
-    cf.readfp(f, 'setup.cfg')
-
-if os.environ.get('GRAPHITE_NO_PREFIX'):
-    cf.remove_section('install')
-else:
-    print('#' * 80)
-    print('')
-    print('Carbon\'s default installation prefix is "/opt/graphite".')
-    print('')
-    print('To install Carbon in the Python\'s default location run:')
-    print('$ GRAPHITE_NO_PREFIX=True python setup.py install')
-    print('')
-    print('#' * 80)
-    try:
-        cf.add_section('install')
-    except DuplicateSectionError:
-        pass
-    if not cf.has_option('install', 'prefix'):
-        cf.set('install', 'prefix', '/opt/graphite')
-    if not cf.has_option('install', 'install-lib'):
-        cf.set('install', 'install-lib', '%(prefix)s/lib')
-
-with open('setup.cfg', 'w') as f:
-    cf.write(f)
-
-
-if os.environ.get('USE_SETUPTOOLS'):
-  from setuptools import setup
-  setup_kwargs = dict(zip_safe=0)
-else:
-  from distutils.core import setup
-  setup_kwargs = dict()
-
-
-storage_dirs = [ ('storage/ceres/dummy.txt', []), ('storage/whisper/dummy.txt',[]),
-                 ('storage/lists',[]), ('storage/log/dummy.txt',[]),
-                 ('storage/rrd/dummy.txt',[]) ]
-conf_files = [ ('conf', glob('conf/*.example')) ]
+storage_dirs = [('storage/ceres/dummy.txt', []), ('storage/whisper/dummy.txt', []),
+                ('storage/lists', []), ('storage/log/dummy.txt', []),
+                ('storage/rrd/dummy.txt', [])]
+conf_files = [('conf', glob('conf/*.example'))]
 
 install_files = storage_dirs + conf_files
 
 # Let's include redhat init scripts, despite build platform
 # but won't put them in /etc/init.d/ automatically anymore
-init_scripts = [ ('examples/init.d', ['distro/redhat/init.d/carbon-cache',
-                                      'distro/redhat/init.d/carbon-relay',
-                                      'distro/redhat/init.d/carbon-aggregator']) ]
+init_scripts = [('examples/init.d', ['distro/redhat/init.d/carbon-cache',
+                                     'distro/redhat/init.d/carbon-relay',
+                                     'distro/redhat/init.d/carbon-aggregator'])]
 install_files += init_scripts
+
 
 def read(fname):
     with open(os.path.join(os.path.dirname(__file__), fname)) as f:
         return f.read()
 
-try:
-    setup(
-        name='carbon',
-        version='1.2.0',
-        url='http://graphiteapp.org/',
-        author='Chris Davis',
-        author_email='chrismd@gmail.com',
-        license='Apache Software License 2.0',
-        description='Backend data caching and persistence daemon for Graphite',
-        long_description=read('README.md'),
-        long_description_content_type='text/markdown',
-        packages=['carbon', 'carbon.aggregator', 'twisted.plugins'],
-        package_dir={'' : 'lib'},
-        scripts=glob('bin/*'),
-        package_data={ 'carbon' : ['*.xml'] },
-        data_files=install_files,
-        install_requires=['Twisted', 'txAMQP', 'cachetools', 'urllib3'],
-        classifiers=(
-            'Intended Audience :: Developers',
-            'Natural Language :: English',
-            'License :: OSI Approved :: Apache Software License',
-            'Programming Language :: Python',
-            'Programming Language :: Python :: 2',
-            'Programming Language :: Python :: 2.7',
-            'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.4',
-            'Programming Language :: Python :: 3.5',
-            'Programming Language :: Python :: 3.6',
-            'Programming Language :: Python :: 3.7',
-            'Programming Language :: Python :: Implementation :: CPython',
-            'Programming Language :: Python :: Implementation :: PyPy',
-        ),
-        **setup_kwargs
-    )
-finally:
-    with open('setup.cfg', 'w') as f:
-        f.write(orig_setup_cfg)
+
+setup(
+    name='carbon',
+    version='1.2.0',
+    url='http://graphiteapp.org/',
+    author='Chris Davis',
+    author_email='chrismd@gmail.com',
+    license='Apache Software License 2.0',
+    description='Backend data caching and persistence daemon for Graphite',
+    long_description=read('README.md'),
+    long_description_content_type='text/markdown',
+    packages=['carbon', 'carbon.aggregator', 'twisted.plugins'],
+    package_dir={'': 'lib'},
+    scripts=glob('bin/*'),
+    package_data={'carbon': ['*.xml']},
+    data_files=install_files,
+    install_requires=['Twisted', 'txAMQP', 'cachetools', 'urllib3'],
+    classifiers=(
+        'Intended Audience :: Developers',
+        'Natural Language :: English',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
+    ),
+    zip_safe=False
+)

--- a/setup.py
+++ b/setup.py
@@ -12,17 +12,11 @@ conf_files = [('conf', glob('conf/*.example'))]
 
 install_files = storage_dirs + conf_files
 
-# Let's include redhat init scripts, despite build platform
-# but won't put them in /etc/init.d/ automatically anymore
-init_scripts = [('examples/init.d', ['distro/redhat/init.d/carbon-cache',
-                                     'distro/redhat/init.d/carbon-relay',
-                                     'distro/redhat/init.d/carbon-aggregator'])]
-install_files += init_scripts
-
 
 def read(fname):
     with open(os.path.join(os.path.dirname(__file__), fname)) as f:
         return f.read()
+
 
 setup(
     name='carbon',


### PR DESCRIPTION
This switches from distutils to setuptools and removes the default `/opt/graphite` prefix.

I think this should go in a major or at least a minor release (no patch release).

Reasons for removing `/opt/graphite` prefix:

- Does not work with setuptools
- Confuses new users/contributors
- Is not common among Python applications
- It is unclear how to disable it
- Causes issues with PYTHONPATH (just google "No module named 'graphite'")
- The code that accomplishes this in setup.py is ugly (rewriting setup.cfg)
- Causes unexpected issues, e.g. https://github.com/graphite-project/carbonate/issues/101
- There are better ways to install in other locations.
- Makes installation of Graphite "harder", have to account for it in your Ansible playbooks/Chef recipes/Puppet Modules.
- Requires `root` privileges on many hosts which don't have a /opt partition
- Pisses me off every time I forget to set the `GRAPHITE_NO_PREFIX` environment variable.

I don't see any reasons for keeping it other than:

- This has been the default for 10 years

If you need to install Graphite in an other location you should use:

- virtualenv/conda (recommended)
- `--user` switch
- `--user` switch and a customized `PYTHONUSERBASE`
- maybe even Docker

[more on custom locations](https://setuptools.readthedocs.io/en/latest/easy_install.html#custom-installation-locations)


Switch to setuptools gets rid of the following warnings:
`UserWarning: Unknown distribution option: 'install_requires'`
`UserWarning: Unknown distribution option: 'long_description_content_type'`

PPA discourages the use of distutils and suggests setuptools. Setuptools has some nice features we can use in future.