### PR TITLE
Fix #871: Adjust aggregator-rules input_pattern match greediness

### DIFF
--- a/lib/carbon/aggregator/rules.py
+++ b/lib/carbon/aggregator/rules.py
@@ -128,7 +128,7 @@ class AggregationRule(object):
         pre = input_part[:i]
         post = input_part[j + 2:]
         field_name = input_part[i + 2:j]
-        regex_part = '%s(?P<%s>.+)%s' % (pre, field_name, post)
+        regex_part = '%s(?P<%s>.+?)%s' % (pre, field_name, post)
 
       else:
         i = input_part.find('<')
@@ -137,7 +137,7 @@ class AggregationRule(object):
           pre = input_part[:i]
           post = input_part[j + 1:]
           field_name = input_part[i + 1:j]
-          regex_part = '%s(?P<%s>[^.]+)%s' % (pre, field_name, post)
+          regex_part = '%s(?P<%s>[^.]+?)%s' % (pre, field_name, post)
         elif input_part == '*':
           regex_part = '[^.]+'
         else:


### PR DESCRIPTION
... to support numeric matching after captured field. Fixes bug #871 .

Before, an input regexp of "collectd.mycluster-\<location\>\d+.app.requests" in aggregation-rules.conf, with a hostname of "mycluster-paris105" would capture "paris10" as the location, instead of paris. With a large cluster this would create a whole lot of aggregates, one per 10 nodes.

This patch makes the \<location\> match not greedy, letting the user-supplied \d+ side to be greedy and eat the 105 away fully, leaving "paris" as the location.