### PR TITLE
Bucketmax write strategy

### DIFF
--- a/conf/carbon.conf.example
+++ b/conf/carbon.conf.example
@@ -165,7 +165,7 @@ LOG_CACHE_QUEUE_SORTS = False
 # disk in that order.
 #
 # timesorted - All metrics in the list will be looked at and sorted according
-# to the timestamp of there datapoints. The metric that were the least recently
+# to the timestamp of their datapoints. The metric that were the least recently
 # written will be written first. This is an hybrid strategy between max and
 # sorted which is particularly adapted to sets of metrics with non-uniform
 # resolutions.
@@ -176,6 +176,12 @@ LOG_CACHE_QUEUE_SORTS = False
 # updated metrics may only ever be persisted to disk at daemon shutdown if
 # there are a large number of metrics which receive very frequent updates OR if
 # disk i/o is very slow.
+#
+# bucketmax (experimental) - As 'max' but uses a different algorithm to
+# determine the metric with the most datapoints.
+# Should perform better than 'max' on most loads, could perform worse if the
+# number of metrics is very small while the number of datapoints per metric is
+# very high.
 #
 # naive - Metrics will be flushed from the cache to disk in an unordered
 # fashion. This strategy may be desirable in situations where the storage for

--- a/lib/carbon/conf.py
+++ b/lib/carbon/conf.py
@@ -276,7 +276,8 @@ class CarbonCacheOptions(usage.Options):
             print("Error: missing required config %s" % storage_schemas)
             sys.exit(1)
 
-        if settings.CACHE_WRITE_STRATEGY not in ('timesorted', 'sorted', 'max', 'naive'):
+        if settings.CACHE_WRITE_STRATEGY not in ('timesorted', 'sorted', 'max',
+                                                 'bucketmax', 'naive'):
             log.err("%s is not a valid value for CACHE_WRITE_STRATEGY, defaulting to %s" %
                     (settings.CACHE_WRITE_STRATEGY, defaults['CACHE_WRITE_STRATEGY']))
         else:

--- a/lib/carbon/tests/benchmark_cache.py
+++ b/lib/carbon/tests/benchmark_cache.py
@@ -1,7 +1,8 @@
 import timeit
 
 from carbon.cache import _MetricCache, DrainStrategy, \
-    NaiveStrategy, MaxStrategy, RandomStrategy, SortedStrategy, TimeSortedStrategy
+    NaiveStrategy, MaxStrategy, RandomStrategy, SortedStrategy, \
+    TimeSortedStrategy, BucketMaxStrategy
 
 
 metric_cache = _MetricCache(DrainStrategy)
@@ -12,6 +13,7 @@ strategies = {
     'random': RandomStrategy,
     'sorted': SortedStrategy,
     'timesorted': TimeSortedStrategy,
+    'bucketmax': BucketMaxStrategy,
 }
 
 
@@ -58,6 +60,20 @@ if __name__ == '__main__':
     for n in [1000, 10000, 100000, 1000000]:
         count = 0
         metric_cache = _MetricCache(DrainStrategy)
+        t = timeit.timeit(command_store_foo_n, number=n)
+        print_stats(n, t)
+
+    print("Benchmarking single metric MetricCache store..., BucketMax")
+    for n in [1000, 10000, 100000, 1000000]:
+        count = 0
+        metric_cache = _MetricCache(BucketMaxStrategy)
+        t = timeit.timeit(command_store_foo, number=n)
+        print_stats(n, t)
+
+    print("Benchmarking unique metric MetricCache store..., BucketMax")
+    for n in [1000, 10000, 100000, 1000000]:
+        count = 0
+        metric_cache = _MetricCache(BucketMaxStrategy)
         t = timeit.timeit(command_store_foo_n, number=n)
         print_stats(n, t)
 


### PR DESCRIPTION
Bucketmax writes the metric with the most datapoints just as max does but uses
a different approach to determine which metric has the most datapoints.

At each write operation 'max' loops once over the list of metrics and picks the metric
with most datapoints.

'bucketmax' stores all metrics in a list where each index represents the number of
datapoints in the specific metrics. For example `buckets[5]` contains a list of all
metrics which have 6 datapoints. At each write operation 'bucketmax' selects the
first metric from the largest bucket.

The time complexity of 'max' is linear, 'bucketmax' is near constant time but runs
on every ingestion where 'max' only runs on every write. There is also some overhead
in resizing the buckets list. I've done some limited testing and 'bucketmax'' CPU
usage was almost half of that of 'max'. The constraint of bucketmax is that the number
of datapoints per metrics must be relatively low compared to the total number of
unique metrics (which I think is the most common use-case in Graphite usage). I don't
know where the tipping point is but if one has for example 10 metrics with each 100000
datapoints I would assume 'bucketmax' would perform worse than 'max'.