### PR TITLE
Trying to fix tests

### DIFF
--- a/lib/carbon/tests/test_client.py
+++ b/lib/carbon/tests/test_client.py
@@ -5,7 +5,6 @@ from carbon.client import (
 )
 from carbon.routers import DatapointRouter
 from carbon.tests.util import TestSettings
-from carbon import instrumentation
 import carbon.service  # NOQA
 
 from twisted.internet import reactor
@@ -44,7 +43,6 @@ class BroadcastRouter(DatapointRouter):
       yield destination
 
 
-#@patch('carbon.state.instrumentation', Mock(spec=instrumentation))
 class ConnectedCarbonClientProtocolTest(TestCase):
   def setUp(self):
     self.router_mock = Mock(spec=DatapointRouter)
@@ -88,7 +86,6 @@ class CarbonLineClientProtocolTest(TestCase):
       self.protocol.sendLine.assert_called_with(expected_line_to_send)
 
 
-#@patch('carbon.state.instrumentation', Mock(spec=instrumentation))
 class CarbonClientFactoryTest(TestCase):
   def setUp(self):
     self.router_mock = Mock(spec=DatapointRouter)
@@ -127,7 +124,6 @@ class CarbonClientFactoryTest(TestCase):
     self.protocol_mock.sendQueued.assert_called_once_with()
 
 
-#@patch('carbon.state.instrumentation', Mock(spec=instrumentation))
 class CarbonClientManagerTest(TestCase):
   timeout = 1.0
 
@@ -190,7 +186,6 @@ class CarbonClientManagerTest(TestCase):
     self.router_mock.removeDestination.assert_called_once_with(dest)
 
 
-#@patch('carbon.state.instrumentation', Mock(spec=instrumentation))
 class RelayProcessorTest(TestCase):
   timeout = 1.0
 

--- a/lib/carbon/tests/test_client.py
+++ b/lib/carbon/tests/test_client.py
@@ -44,7 +44,7 @@ class BroadcastRouter(DatapointRouter):
       yield destination
 
 
-@patch('carbon.state.instrumentation', Mock(spec=instrumentation))
+#@patch('carbon.state.instrumentation', Mock(spec=instrumentation))
 class ConnectedCarbonClientProtocolTest(TestCase):
   def setUp(self):
     self.router_mock = Mock(spec=DatapointRouter)
@@ -88,7 +88,7 @@ class CarbonLineClientProtocolTest(TestCase):
       self.protocol.sendLine.assert_called_with(expected_line_to_send)
 
 
-@patch('carbon.state.instrumentation', Mock(spec=instrumentation))
+#@patch('carbon.state.instrumentation', Mock(spec=instrumentation))
 class CarbonClientFactoryTest(TestCase):
   def setUp(self):
     self.router_mock = Mock(spec=DatapointRouter)
@@ -127,7 +127,7 @@ class CarbonClientFactoryTest(TestCase):
     self.protocol_mock.sendQueued.assert_called_once_with()
 
 
-@patch('carbon.state.instrumentation', Mock(spec=instrumentation))
+#@patch('carbon.state.instrumentation', Mock(spec=instrumentation))
 class CarbonClientManagerTest(TestCase):
   timeout = 1.0
 
@@ -190,7 +190,7 @@ class CarbonClientManagerTest(TestCase):
     self.router_mock.removeDestination.assert_called_once_with(dest)
 
 
-@patch('carbon.state.instrumentation', Mock(spec=instrumentation))
+#@patch('carbon.state.instrumentation', Mock(spec=instrumentation))
 class RelayProcessorTest(TestCase):
   timeout = 1.0
 

--- a/lib/carbon/tests/test_protobuf.py
+++ b/lib/carbon/tests/test_protobuf.py
@@ -35,7 +35,7 @@ def decode_sent(data):
   return datapoints
 
 
-@patch('carbon.state.instrumentation', Mock(spec=instrumentation))
+#@patch('carbon.state.instrumentation', Mock(spec=instrumentation))
 class ConnectedCarbonClientProtocolTest(TestCase):
   def setUp(self):
     self.router_mock = Mock(spec=DatapointRouter)

--- a/lib/carbon/tests/test_protobuf.py
+++ b/lib/carbon/tests/test_protobuf.py
@@ -1,7 +1,6 @@
 import carbon.client as carbon_client
 from carbon.routers import DatapointRouter
 from carbon.tests.util import TestSettings
-from carbon import instrumentation
 import carbon.service  # NOQA
 
 from carbon.carbon_pb2 import Payload
@@ -35,7 +34,6 @@ def decode_sent(data):
   return datapoints
 
 
-#@patch('carbon.state.instrumentation', Mock(spec=instrumentation))
 class ConnectedCarbonClientProtocolTest(TestCase):
   def setUp(self):
     self.router_mock = Mock(spec=DatapointRouter)

--- a/lib/carbon/tests/test_protobuf.py
+++ b/lib/carbon/tests/test_protobuf.py
@@ -13,7 +13,7 @@ from twisted.internet.task import deferLater
 from twisted.trial.unittest import TestCase
 from twisted.test.proto_helpers import StringTransport
 
-from mock import Mock, patch
+from mock import Mock
 from struct import unpack, calcsize
 
 


### PR DESCRIPTION
Not sure why we mocking 'carbon.state.instrumentation' here.
It recently start to give following error:
```python
Traceback (most recent call last):
  File "/Users/dzhdanov/git/carbon/.tox/py37/lib/python3.7/site-packages/twisted/trial/runner.py", line 531, in loadPackage
    module = modinfo.load()
  File "/Users/dzhdanov/git/carbon/.tox/py37/lib/python3.7/site-packages/twisted/python/modules.py", line 392, in load
    return self.pathEntry.pythonPath.moduleLoader(self.name)
  File "/Users/dzhdanov/git/carbon/.tox/py37/lib/python3.7/site-packages/twisted/python/reflect.py", line 308, in namedAny
    topLevelPackage = _importAndCheckStack(trialname)
  File "/Users/dzhdanov/git/carbon/.tox/py37/lib/python3.7/site-packages/twisted/python/reflect.py", line 247, in _importAndCheckStack
    return __import__(importName)
  File "/Users/dzhdanov/git/carbon/lib/carbon/tests/test_client.py", line 91, in <module>
    @patch('carbon.state.instrumentation', Mock(spec=instrumentation))
  File "/Users/dzhdanov/git/carbon/.tox/py37/lib/python3.7/site-packages/mock/mock.py", line 1084, in __init__
    _spec_state, _new_name, _new_parent, **kwargs
  File "/Users/dzhdanov/git/carbon/.tox/py37/lib/python3.7/site-packages/mock/mock.py", line 439, in __init__
    self._mock_add_spec(spec, spec_set, _spec_as_instance, _eat_self)
  File "/Users/dzhdanov/git/carbon/.tox/py37/lib/python3.7/site-packages/mock/mock.py", line 494, in _mock_add_spec
    if iscoroutinefunction(getattr(spec, attr, None)):
  File "/Users/dzhdanov/git/carbon/.tox/py37/lib/python3.7/site-packages/mock/backports.py", line 34, in iscoroutinefunction
    getattr(obj, '_is_coroutine', None) is _is_coroutine
builtins.KeyError: '_is_coroutine'
```
Commenting out works fine.
Did someone maybe know why that happening and how we can fix it properly?
@piotr1212 @DanCech ?