### PR TITLE
Update storage-aggregation.conf.example for #768

### DIFF
--- a/conf/storage-aggregation.conf.example
+++ b/conf/storage-aggregation.conf.example
@@ -24,7 +24,10 @@ aggregationMethod = max
 [sum]
 pattern = \.count$
 xFilesFactor = 0
+# for monotonically increasing counters
 aggregationMethod = max
+# for counters that reset every interval (statsd-style)
+#aggregationMethod = sum
 
 [default_average]
 pattern = .*


### PR DESCRIPTION
see #768

Previously for counters aggregationMethod was sum, now it is max
https://github.com/graphite-project/carbon/commit/e4953da4a37c07177fdccb1abda3679e017a83e8

This is good for use case described in https://answers.launchpad.net/graphite/+question/286462 but wrong for statsd counters which are reset every (statsd) flush interval.
