### PR TITLE
Switching x86 arch tests to Github Actions

### DIFF
--- a/.github/workflows/tests-amd64.yml
+++ b/.github/workflows/tests-amd64.yml
@@ -34,12 +34,12 @@ jobs:
           - name: "Python 3.8"
             python-version: '3.8'
             toxenv: 'py38'
-          - name: "Python 3.9"
-            python-version: '3.9'
-            toxenv: 'py39'
           - name: "Python 3.9-pyhash"
             python-version: '3.9'
             toxenv: 'py39-pyhash'
+          - name: "Python 3.9"
+            python-version: '3.9'
+            toxenv: 'py39'
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests-amd64.yml
+++ b/.github/workflows/tests-amd64.yml
@@ -1,0 +1,75 @@
+name: "Run tests for amd64 architecture"
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        include:
+          - name: "Python 2.7"
+            python-version: '2.7'
+            toxenv: "py27"
+          - name: "Pypy 2.7"
+            python-version: 'pypy-2.7'
+            toxenv: 'pypy'
+          - name: "Python 3.6"
+            python-version: '3.6'
+            toxenv: 'py36'
+          - name: "Pypy 3.6"
+            python-version: 'pypy-3.6'
+            toxenv: 'pypy3'
+          - name: "Python 3.7"
+            python-version: '3.7'
+            toxenv: 'py37'
+          - name: "Pypy 3.7"
+            python-version: 'pypy-3.7'
+            toxenv: 'pypy3'
+          - name: "Python 3.8"
+            python-version: '3.8'
+            toxenv: 'py38'
+          - name: "Python 3.9"
+            python-version: '3.9'
+            toxenv: 'py39'
+          - name: "Python 3.9-pyhash"
+            python-version: '3.9'
+            toxenv: 'py39-pyhash'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          apt-get -q install -y libboost-python-dev
+          python -m pip install --upgrade pip
+          pip install tox flake8 pytest
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Tests with tox
+        env:
+          TOXENV: ${{ matrix.toxenv }}
+        run: |
+          tox
+      - name: Linting
+        if: ${{ matrix.python-version==3.9 }}
+        env:
+          TOXENV: lint
+        run: |
+          tox
+      - name: Run Codecov
+        if: ${{ matrix.python-version==3.9 }}
+        env:
+          TOXENV: lint
+        run: |
+          pip install codecov
+          codecov
+      - name: Upload coverage to Codecov
+        if: ${{ matrix.python-version==3.9 }}
+        uses: codecov/codecov-action@v1

--- a/.github/workflows/tests-amd64.yml
+++ b/.github/workflows/tests-amd64.yml
@@ -48,7 +48,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          apt-get -q install -y libboost-python-dev
           python -m pip install --upgrade pip
           pip install tox flake8 pytest
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,46 +1,14 @@
 # http://travis-ci.org/#!/graphite-project/carbon
-dist: xenial
+dist: bionic
 language: python
-python: 3.8
+python: 3.9
 
 matrix:
   include:
-    - python: pypy
-      env:
-        - TOXENV=pypy
-    - python: pypy3
-      env:
-        - TOXENV=pypy3
-    - python: 3.5
-      env:
-        - TOXENV=py35
-    - python: 3.6
-      env:
-        - TOXENV=py36
-    - python: 3.7
-      env:
-        - TOXENV=py37
-    - python: 3.8
-      env:
-        - TOXENV=py38-pyhash
-    - python: 3.8
-      env:
-        - TOXENV=py38
-    - python: 3.8
-      env:
-        - TOXENV=lint
     - python: 2.7
       arch: s390x
       env:
         - TOXENV=py27
-    - python: 2.7
-      arch: s390x
-      env:
-        - TOXENV=lint
-    - python: 3.5
-      arch: s390x
-      env:
-        - TOXENV=py35
     - python: 3.6
       arch: s390x
       env:
@@ -53,7 +21,11 @@ matrix:
       arch: s390x
       env:
         - TOXENV=py38
-    - python: 3.8
+    - python: 3.9
+      arch: s390x
+      env:
+        - TOXENV=py39
+    - python: 3.9
       arch: s390x
       env:
         - TOXENV=lint
@@ -62,10 +34,6 @@ matrix:
       arch: ppc64le
       env:
         - TOXENV=py27
-    - python: 3.5
-      arch: ppc64le
-      env:
-        - TOXENV=py35
     - python: 3.6
       arch: ppc64le
       env:
@@ -78,10 +46,18 @@ matrix:
       arch: ppc64le
       env:
         - TOXENV=py38
+    - python: 3.9
+      arch: ppc64le
+      env:
+        - TOXENV=py39
+    - python: 3.9
+      arch: ppc64le
+      env:
+        - TOXENV=lint
 
 env:
-  - TOXENV=py38
-  - TOXENV=py38-pyhash
+  - TOXENV=py39
+  - TOXENV=py39-pyhash
   - TOXENV=lint
 
 install:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-  py{27,35,36,37,38,py,py3}{,-pyhash},
+  py{27,36,37,38,39,py,py3}{,-pyhash},
   lint,
   benchmark
 


### PR DESCRIPTION
 - Removing py3.5
 - Keeping only s390 and ppc64le tests in Travis (not sure if they still works). Theoretically we can migrate to https://github.com/uraimo/run-on-arch-action but then we need to set up every python manually, which can be non trivial