### PR TITLE
Don't use git protocol for dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Twisted>=13.2.0
-git+git://github.com/graphite-project/whisper.git#egg=whisper
+git+https://github.com/graphite-project/whisper.git#egg=whisper
 txAMQP
 cachetools
 urllib3


### PR DESCRIPTION
Unauthenticated git access has been [disabled by Github](https://github.blog/2021-09-01-improving-git-protocol-security-github/). This dependency causes carbon to fail during installation in many environments, e.g. docker containers with no other authentication set up.

```

#13 2.527 Collecting whisper |  
-- | --
  | #13 2.528   Cloning git://github.com/graphite-project/whisper.git to /tmp/pip-install-wz3idsrz/whisper_7e23b2a5d1834eaebec6a22002e118ce |  
  | #13 2.531   Running command git clone --filter=blob:none --quiet git://github.com/graphite-project/whisper.git /tmp/pip-install-wz3idsrz/whisper_7e23b2a5d1834eaebec6a22002e118ce |  
  | #13 3.105   fatal: remote error: |  
  | #13 3.105     The unauthenticated git protocol on port 9418 is no longer supported.

```

Switching to HTTP should be issue-free, and matches the [dependency in the graphite-web project](https://github.com/graphite-project/graphite-web/blob/master/requirements.txt#L48).