### PR TITLE
fix log.py warning about buffering

### DIFF
--- a/lib/carbon/log.py
+++ b/lib/carbon/log.py
@@ -20,7 +20,7 @@ class CarbonLogFile(DailyLogFile):
     Fix Umask Issue https://twistedmatrix.com/trac/ticket/7026
     """
     openMode = self.defaultMode or 0o777
-    # Fix >= Python3.8 raises RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode
+    # Fix >= Python3.8 raises RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode  # NOQA
     python_version = '%s.%s.%s' % (str(version_info[0]), str(version_info[1]), str(version_info[2]))
     use_buffering = 0
     if python_version < '3.8.0':

--- a/lib/carbon/log.py
+++ b/lib/carbon/log.py
@@ -1,6 +1,6 @@
 import os
 import time
-from sys import stdout
+from sys import stdout, version_info
 from zope.interface import implementer
 from twisted.python.log import startLoggingWithObserver, textFromEventDict, msg, err, ILogObserver  # NOQA
 from twisted.python.syslog import SyslogObserver
@@ -20,8 +20,13 @@ class CarbonLogFile(DailyLogFile):
     Fix Umask Issue https://twistedmatrix.com/trac/ticket/7026
     """
     openMode = self.defaultMode or 0o777
+    # Fix >= Python3.8 raises RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode
+    python_version = '%s.%s.%s' % (str(version_info[0]), str(version_info[1]), str(version_info[2]))
+    use_buffering = 0
+    if python_version < '3.8.0':
+      use_buffering = 1
     self._file = os.fdopen(os.open(
-      self.path, os.O_CREAT | os.O_RDWR, openMode), 'rb+', 1)
+      self.path, os.O_CREAT | os.O_RDWR, openMode), 'rb+', use_buffering)
     self.closed = False
     # Try our best to update permissions for files which already exist.
     if self.defaultMode:


### PR DESCRIPTION
This is a fix for  Python 3.9.6 causes warning about buffering for binary mode #922, setting this to 0 is the default behaviour and results in the default buffer size being used.

The warning was released in Python 3.8.0 and is still present in 3.10.13 (tested, works and logging works fine) and is still present in 3.12.2 (https://github.com/python/cpython/blob/v3.12.2/Lib/_pyio.py#L231)

The version check may be excessive because who would be running < 3.8.0, but you never know.