### PR TITLE
Update rewrite-rules.conf.example - explicitly state aggregator

### DIFF
--- a/conf/rewrite-rules.conf.example
+++ b/conf/rewrite-rules.conf.example
@@ -1,8 +1,9 @@
-# This file defines regular expression patterns that can be used to
+# This file defines regular expression patterns that can be used by
+# carbon-aggregator (as per [aggregator] section of carbon.conf) to
 # rewrite metric names in a search & replace fashion. It consists of two
 # sections, [pre] and [post]. The rules in the pre section are applied to
-# metric names as soon as they are received. The post rules are applied
-# after aggregation has taken place.
+# metric names as soon as they are received by aggregator. The post rules
+# are applied after aggregation has taken place.
 #
 # The general form of each rule is as follows:
 #


### PR DESCRIPTION
Explicitly state and relate rewrite-rules.conf to carbon-aggregator so that this info is available to the user in-situ in the example. There is ambiguity in the phrase "as soon as they are received" this can confusing because carbon-relay could be seen as where they are being received.

Related to https://github.com/graphite-project/graphite-web/pull/2845 which tries to make it clearer in the docs as well.