### PR TITLE
Allow the aggregator to consistently accept past data

### DIFF
--- a/conf/carbon.conf.example
+++ b/conf/carbon.conf.example
@@ -637,9 +637,16 @@ USE_FLOW_CONTROL = True
 # You shouldn't need to tune this unless you really know what you're doing.
 MAX_DATAPOINTS_PER_MESSAGE = 500
 
-# This defines how many datapoints the aggregator remembers for
-# each metric. Aggregation only happens for datapoints that fall in
-# the past MAX_AGGREGATION_INTERVALS * intervalSize seconds.
+# This defines how many intervals behind the current one the aggregator
+# remembers for each metric. Intervals are expired when either:
+#   * They have seen no new datapoints in the last
+#   (MAX_AGGREGATION_INTERVALS * configured_frequency) seconds, or
+#   * There are more than (MAX_AGGREGATION_INTERVALS + 2) intervals with
+#   datapoints in them. (This allows an application to replay past metrics with
+#   sensible behaviour.)
+# Intervals are expired only when they are aggregated.
+# Expired intervals will be treated as empty if new datapoints arrive.
+# See WRITE_BACK_FREQUENCY to control the aggregation frequency.
 MAX_AGGREGATION_INTERVALS = 5
 
 # Limit the number of open connections the receiver can handle as any time.


### PR DESCRIPTION
The discovery of #956 was due to replaying a huge swathe of past data into our aggregator instance and finding the data full of holes. I'd assumed it was due to early-expiry of old `IntervalBuffer` objects, but after writing this fix I found this wasn't the case. However, the behaviour is still likely incorrect when data is played over an aggregation interval. Suppose the aggregator config is:

```
a (60) = sum a
```

And the input is:

```
a 0 1
...
a 1 19
<aggregation timeout triggers here at time (MAX_AGGREGATION_INTERVALS + 1) * 60 or higher>
a 1 20
...
a 1 59
```

Then the aggregation will aggregate seconds 0-29 and output this (value 20) to the cache, then expire the interval as it's too old, then in the next timeout, aggregate seconds 31-60, output this to the cache and expire the interval again. The final value is the aggregate of seconds 20-59, which is 40 instead of the expected 60. There is no way to control when aggregation occurs, so replayed data will be inconsistent, and in this case could be any value between 1 and 60, though if the replay is faster than real-time, the most likely will be 60.

After these changes, we allow the system to keep the newest interval prior to the current time-frame, provided it's been _submitted_ within the current time-frame. This means if old data is submitted in-order, as would be expected from a replay, the intervals will always be aggregated in a complete state at least once before expiry. This is somewhat robust to curiosities in the timestamps of the real-time submitting process (for example, if that process happens to round time down, or be pushing a prediction of future data or similar), as the number of kept intervals is based on submission time rather than interval time.