### PR TITLE
Create metrics in a queue which can be processed in advance of the write queue

### DIFF
--- a/lib/carbon/cache.py
+++ b/lib/carbon/cache.py
@@ -16,7 +16,7 @@ import time
 import threading
 from operator import itemgetter
 from random import choice
-from collections import defaultdict
+from collections import defaultdict, deque
 
 from carbon.conf import settings
 from carbon import events, log
@@ -189,6 +189,7 @@ class _MetricCache(defaultdict):
   def __init__(self, strategy=None):
     self.lock = threading.Lock()
     self.size = 0
+    self.new_metrics = deque()
     self.strategy = None
     if strategy:
       self.strategy = strategy(self)
@@ -253,6 +254,8 @@ class _MetricCache(defaultdict):
           log.msg("MetricCache is full: self.size=%d" % self.size)
           events.cacheFull()
         else:
+          if not self[metric]:
+            self.new_metrics.append(metric)
           self.size += 1
           self[metric][timestamp] = value
           if self.strategy:

--- a/lib/carbon/util.py
+++ b/lib/carbon/util.py
@@ -287,7 +287,7 @@ class TokenBucket(object):
     '''Given a number of tokens (or fractions) drain will return True and
     drain the number of tokens from the bucket if the capacity allows,
     otherwise we return false and leave the contents of the bucket.'''
-    if cost <= self.tokens:
+    if self.peek(cost):
       self._tokens -= cost
       return True
 
@@ -310,16 +310,16 @@ class TokenBucket(object):
     self.fill_rate = float(new_fill_rate)
     self._tokens = delta + self._tokens
 
-  @property
-  def tokens(self):
-    '''The tokens property will return the current number of tokens in the
-    bucket.'''
-    if self._tokens < self.capacity:
+  def peek(self, cost):
+    '''Return true if the bucket can drain cost without blocking.'''
+    if self._tokens >= cost:
+      return True
+    else:
       now = time()
       delta = self.fill_rate * (now - self.timestamp)
       self._tokens = min(self.capacity, self._tokens + delta)
       self.timestamp = now
-    return self._tokens
+      return self._tokens >= cost
 
 
 class PluginRegistrar(type):


### PR DESCRIPTION
We've had this on a moderately sized production system for some time now and haven't spotted any problems. I started with work on #888 by @ploxiln and the original work by @piotr1212, but this approach is slightly different, and happens to have a slightly more readable diff. Differences:

* We don't drop excessive creates, instead we just queue them like with updates. This matters a lot on our setup, where large numbers of metrics often get created in bursts, and we'd rather not lose data from them.
* It's (more) robust to database files getting deleted under its hood. This will cause a `droppedCreate` rather than an exception, I think.

There are a few behaviour changes:

* We'll create new metrics at the maximum rate possible until there are none left to create. The create bucket should likely therefore be tuned not to be able to overwhelm the write bandwidth -- though if this happens, the cache is going to be unable to keep up anyway.
  * If the update bucket is empty, this can delay creates, as the thread can be blocked there for one update even if a create is possible first. This is unlikely to delay creates by very much.
* Empty Whisper files will now be created, as the create step doesn't write data into the resulting file.
* Creates are now dropped only when the cache tries to fill the new metric and finds its absent. This should be exceedingly unlikely under most of the write strategies.
* If a "live" whisper file is deleted, we'll drop all datapoints and log a dropped create when we attempt to write to it next. If there are further datapoints after this, the metric should be recreated. The old behaviour would have created the file on the write attempt.

Deprecates #888

Fixes https://github.com/graphite-project/graphite-web/issues/629