### PR TITLE
Fix version comparison logic for Python >= 3.8 in log.py

### DIFF
--- a/lib/carbon/log.py
+++ b/lib/carbon/log.py
@@ -21,9 +21,9 @@ class CarbonLogFile(DailyLogFile):
     """
     openMode = self.defaultMode or 0o777
     # Fix >= Python3.8 raises RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode  # NOQA
-    python_version = '%s.%s.%s' % (str(version_info[0]), str(version_info[1]), str(version_info[2]))
+    python_version = version_info[:3]
     use_buffering = 0
-    if python_version < '3.8.0':
+    if python_version < (3, 8, 0):
       use_buffering = 1
     self._file = os.fdopen(os.open(
       self.path, os.O_CREAT | os.O_RDWR, openMode), 'rb+', use_buffering)


### PR DESCRIPTION
### Problem
The previous implementation compared Python versions as strings, which could lead to incorrect behavior. For example, `'3.11.0' < '3.8.0'` evaluates to `True` due to lexicographical ordering.

### Solution
This commit modifies the version comparison to use `sys.version_info[:3]`, which provides a tuple of the major, minor, and micro components of the Python version. This ensures a correct numeric comparison.

### Testing
Tested the change on Python versions 3.8 to verify correct behavior.
